### PR TITLE
VERY dirty rendering

### DIFF
--- a/kivent_tutorials/8_airhockey_table/yourappname.kv
+++ b/kivent_tutorials/8_airhockey_table/yourappname.kv
@@ -41,7 +41,7 @@ TestGame:
             map_size: (1920., 1080.)
             gameworld: gameworld
 
-        Renderer:
+        DirtyRenderer:
             gameworld: gameworld
             system_id: 'renderer'
             gameview: 'gameview'

--- a/modules/core/kivent_core/gamesystems.pxd
+++ b/modules/core/kivent_core/gamesystems.pxd
@@ -1,3 +1,4 @@
+from cpython cimport bool
 cdef class ColorComponent:
     cdef float _r
     cdef float _g
@@ -10,6 +11,7 @@ cdef class PositionComponent:
 
 cdef class ScaleComponent:
     cdef float _s
+    cdef int _dirty
 
 cdef class RotateComponent:
     cdef float _r

--- a/modules/core/kivent_core/gamesystems.pyx
+++ b/modules/core/kivent_core/gamesystems.pyx
@@ -29,17 +29,25 @@ cdef class RotateComponent:
         def __set__(self, float value):
             self._r = value
 
+
 @cython.freelist(100)
 cdef class ScaleComponent:
 
     def __cinit__(self, float s):
         self._s = s
+        self._dirty = 10
 
     property s:
         def __get__(self):
             return self._s
         def __set__(self, float value):
             self._s = value
+            self._dirty = 1
+    property dirty:
+        def __get__(self):
+            return self._dirty
+        def __set__(self, int value):
+            self._dirty = value
 
 @cython.freelist(100)
 cdef class PositionComponent:

--- a/modules/core/kivent_core/renderers.pxd
+++ b/modules/core/kivent_core/renderers.pxd
@@ -9,6 +9,7 @@ cdef class TextureManager:
 
 cdef class RenderComponent:
     cdef bool _render
+    cdef bool _dirty
     cdef str _texture_key
     cdef VertMesh _vert_mesh
     cdef int _attrib_count


### PR DESCRIPTION
warning, rather hackey. do not merge.

not suitable for nearly anything except light hockey, as static objects never change anything without changing scale

ScaleComponent now contains an int _dirty, initialised at 10. Each render, 1 is subtracted from _dirty. Render is skipped if less than 0
changing scale sets _dirty to 1

Though it'd take a bit of a rethink to make this more general case, in Light Hockey the time taken by update@renders.pyx is nearly cut in half.
