### PR TITLE
- allow to call Entity.get_component_index from python

### DIFF
--- a/modules/core/kivent_core/entity.pxd
+++ b/modules/core/kivent_core/entity.pxd
@@ -6,4 +6,3 @@ cdef class Entity(MemComponent):
     cdef SystemManager system_manager
     cdef void set_component(self, unsigned int component_id, 
         unsigned int system_id)
-    cdef unsigned int get_component_index(self, str name)

--- a/modules/core/kivent_core/entity.pxd
+++ b/modules/core/kivent_core/entity.pxd
@@ -6,3 +6,6 @@ cdef class Entity(MemComponent):
     cdef SystemManager system_manager
     cdef void set_component(self, unsigned int component_id, 
         unsigned int system_id)
+    cpdef unsigned int get_component_index(self, str name)
+
+

--- a/modules/core/kivent_core/entity.pyx
+++ b/modules/core/kivent_core/entity.pyx
@@ -68,7 +68,7 @@ cdef class Entity(MemComponent):
         cdef unsigned int* pointer = <unsigned int*>self.pointer
         pointer[system_index+1] = component_id
 
-    cdef unsigned int get_component_index(self, str name):
+    def get_component_index(self, str name):
         '''Gets the index of the component for GameSystem with system_id name.
         Args:
             name (str): The system_id of the GameSystem to retrieve the 

--- a/modules/core/kivent_core/entity.pyx
+++ b/modules/core/kivent_core/entity.pyx
@@ -68,7 +68,7 @@ cdef class Entity(MemComponent):
         cdef unsigned int* pointer = <unsigned int*>self.pointer
         pointer[system_index+1] = component_id
 
-    def get_component_index(self, str name):
+    cpdef unsigned int get_component_index(self, str name):
         '''Gets the index of the component for GameSystem with system_id name.
         Args:
             name (str): The system_id of the GameSystem to retrieve the 


### PR DESCRIPTION
I was not able to call get_component_index from python, so I was not able to remove component from entity. 

I'm Cython expert so I'm not sure if it's right way to achieve it. 