### PR TITLE
uncaught KeyError in cdefed metchod

### DIFF
--- a/modules/core/kivent_core/managers/system_manager.pyx
+++ b/modules/core/kivent_core/managers/system_manager.pyx
@@ -199,7 +199,10 @@ cdef class SystemManager:
             system_index (unsigned int): Index of the system in the **systems**
             list.
         '''
-        return self.system_index[system_name] 
+        try:
+            return self.system_index[system_name]
+        except KeyError:
+            return -1
 
     def set_system_count(self, unsigned int system_count):
         '''Set the system_count, which is the number of systems that will


### PR DESCRIPTION
When you type:

<code>entity.non_existing_component</code>

the SystemManager.get_system_index method raises KeyError, but since it's cdefed, the exception is not propagated. In case of KeyError the get_system_index returns 0, which leads to getting wrong component.