### PR TITLE
Shore up all the bolierplate in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.swp
 *.egg-info
 build
+dist
+.eggs

--- a/README.md
+++ b/README.md
@@ -43,16 +43,32 @@ Other modules may have other dependecies, listed here:
 first install all dependencies then:
 
     cd .../KivEnt/modules/core
-    python setup.py build_ext install
+    python setup.py install
 or
 
     cd .../KivEnt/modules/cymunk
-    python setup.py build_ext install
+    python setup.py install
 
 If you want to install into a system python on something like ubuntu you may need to:
 
-    sudo python setup.py build_ext install
-    
+    sudo python setup.py install
+
+If you would like to develop on one of the modules while using it
+
+    python setup.py build_ext --inplace develop
+
+Then if you change one of the cython files in that modules
+
+    python setup.py build_ext --inplace
+
+Because of the 'develop' install type, your kivent module will be loading the
+.pyd or .so files from the same directory as the .pyx code and thus build_ext --inplace
+is all thats needed to update the necessary files for the changes you made
+
+If you want to make sure all the cython files are re compiled
+
+    python setup.py cythoninze --clean build_ext --inplace
+
 If you would like to instead build the modules in place and use PYTHONPATH to find them:
 
     cd .../KivEnt/modules/core

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ or
 
 If you want to install into a system python on something like ubuntu you may need to:
 
-    sudo python setup.py install
+    sudo python setup.py build_ext install
 
 If you would like to develop on one of the modules while using it
 
@@ -65,7 +65,7 @@ Because of the 'develop' install type, your kivent module will be loading the
 .pyd or .so files from the same directory as the .pyx code and thus build_ext --inplace
 is all thats needed to update the necessary files for the changes you made
 
-If you want to make sure all the cython files are re compiled
+If you want to make sure all the cython files are re compiled for your develop install
 
     python setup.py cythoninze --clean build_ext --inplace
 

--- a/examples/3_creating_a_gamesystem/setup.py
+++ b/examples/3_creating_a_gamesystem/setup.py
@@ -1,72 +1,12 @@
-from os import environ, remove
-from os.path import dirname, join, isfile
-from distutils.core import setup
-from distutils.extension import Extension
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-    have_cython = True
-except ImportError:
-    have_cython = False
 import sys
+from setuptools import setup, find_packages
 
-platform = sys.platform
-if platform == 'win32':
-	cstdarg = '-std=gnu99'
+if sys.platform == 'win32':
+    compile_args = ['-std=gnu99', '-ffast-math']
+    libraries = ['opengl32', 'glu32','glew32']
 else:
-	cstdarg = '-std=c99'
-
-do_clear_existing = True
-
-
-
-velocity_modules = {
-    'velocity_module.velocity': ['velocity_module/velocity.pyx',],
-    }
-
-velocity_modules_c = {
-    'velocity_module.velocity': ['velocity_module/velocity.c',],
-    }
-
-check_for_removal = ['velocity_module/velocity.c',]
-
-def build_ext(ext_name, files, include_dirs=[]):
-    return Extension(ext_name, files, include_dirs,
-        extra_compile_args=[cstdarg, '-ffast-math',])
-
-extensions = []
-velocity_extensions = []
-cmdclass = {}
-
-def build_extensions_for_modules_cython(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name])
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return cythonize(ext_list)
-
-def build_extensions_for_modules(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name])
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return ext_list
-
-if have_cython:
-    if do_clear_existing:
-        for file_name in check_for_removal:
-            if isfile(file_name):
-                remove(file_name)
-    velocity_extensions = build_extensions_for_modules_cython(
-        velocity_extensions, velocity_modules)
-else:
-    velocity_extensions = build_extensions_for_modules(velocity_extensions, 
-        velocity_modules_c)
-
+    compile_args = ['-std=c99', '-ffast-math', "-w"]
+    libraries = []
 
 setup(
     name='KivEnt Velocity Module',
@@ -74,9 +14,14 @@ setup(
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
-    ext_modules=velocity_extensions,
-    cmdclass=cmdclass,
-    packages=[
-        'velocity_module',
-        ],
-    package_dir={'velocity_module': 'velocity_module'})
+    packages=find_packages(),
+    package_data={
+        '': ['*.pxd']
+    },
+    setup_requires=['cython', 'setuptools.autocythonize'],
+    auto_cythonize={
+        "compile_args": compile_args,
+        "libraries": libraries,
+        "includes": kivy.get_includes()
+    }
+)

--- a/examples/3_creating_a_gamesystem/setup.py
+++ b/examples/3_creating_a_gamesystem/setup.py
@@ -9,14 +9,14 @@ else:
     libraries = []
 
 setup(
-    name='KivEnt Velocity Module',
-    description='''A game engine for the Kivy Framework. 
+    name='KivEnt.Velocity',
+    description='''A game engine for the Kivy Framework.
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
     packages=find_packages(),
     package_data={
-        '': ['*.pxd']
+        '': ['*.pxd', '*.so']
     },
     setup_requires=['cython', 'setuptools.autocythonize'],
     auto_cythonize={

--- a/modules/core/setup.py
+++ b/modules/core/setup.py
@@ -1,144 +1,28 @@
-from os import environ, remove
-from os.path import dirname, join, isfile
-from distutils.core import setup
-from distutils.extension import Extension
-import kivy
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-    have_cython = True
-except ImportError:
-    have_cython = False
 import sys
+from setuptools import setup, find_packages
+import kivy
 
-platform = sys.platform
-if platform == 'win32':
-    cstdarg = '-std=gnu99'
-    libraries=['opengl32', 'glu32','glew32']
+if sys.platform == 'win32':
+    compile_args = ['-std=gnu99', '-ffast-math']
+    libraries = ['opengl32', 'glu32','glew32']
 else:
-    cstdarg = '-std=c99'
-    libraries=[]
-
-do_clear_existing = False
-
-prefixes = {
-    'core': 'kivent_core.',
-    'memory_handlers': 'kivent_core.memory_handlers.',
-    'rendering': 'kivent_core.rendering.',
-    'managers': 'kivent_core.managers.',
-    'uix': 'kivent_core.uix.',
-    'systems': 'kivent_core.systems.'
-}
-
-file_prefixes = {
-    'core': 'kivent_core/',
-    'memory_handlers': 'kivent_core/memory_handlers/',
-    'rendering': 'kivent_core/rendering/',
-    'managers': 'kivent_core/managers/',
-    'uix': 'kivent_core/uix/',
-    'systems': 'kivent_core/systems/'
-}
-
-modules = {
-    'core': ['entity', 'gameworld'],
-    'memory_handlers': [
-        'block', 'membuffer', 'indexing', 'pool', 'utils', 
-        'zone', 'tests', 'zonedblock'
-        ],
-    'rendering': [
-        'gl_debug', 'vertex_format', 'fixedvbo', 'cmesh', 'batching', 
-        'vertex_format', 'frame_objects','vertex_formats', 'model',
-        'svg_loader'
-        ],
-    'managers': [
-        'resource_managers', 'system_manager', 'entity_manager', 
-        'sound_manager',
-        ],
-    'uix': ['cwidget', 'gamescreens'],
-    'systems': [
-        'gamesystem', 'staticmemgamesystem', 'position_systems',
-        'gameview', 'scale_systems', 'rotate_systems', 'color_systems',
-        'gamemap', 'renderers', 'lifespan'
-        ],
-   }
-   
-core_modules = {}
-core_modules_c = {}
-check_for_removal = []
-
-for name in modules:
-    file_prefix = file_prefixes[name]
-    prefix = prefixes[name]
-    module_files = modules[name]
-    for module_name in module_files:
-        core_modules[prefix+module_name] = [file_prefix + module_name + '.pyx']
-        core_modules_c[prefix+module_name] = [file_prefix + module_name + '.c']
-        check_for_removal.append(file_prefix + module_name + '.c')
-
-
-def build_ext(ext_name, files, include_dirs=[]):
-    return Extension(ext_name, files, include_dirs,
-        extra_compile_args=[cstdarg, '-ffast-math',],
-        libraries=libraries)
-
-extensions = []
-cymunk_extensions = []
-cmdclass = {}
-
-def build_extensions_for_modules_cython(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-            include_dirs=kivy.get_includes())
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return cythonize(ext_list)
-
-def build_extensions_for_modules(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-            include_dirs=kivy.get_includes())
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return ext_list
-
-if have_cython:
-    if do_clear_existing:
-        for file_name in check_for_removal:
-            if isfile(file_name):
-                remove(file_name)
-    core_extensions = build_extensions_for_modules_cython(
-        extensions, core_modules)
-else:
-    core_extensions = build_extensions_for_modules(extensions, core_modules_c)
-
+    compile_args = ['-std=c99', '-ffast-math', '-w']
+    libraries = []
 
 setup(
-    name='KivEnt Core',
-    description='''A game engine for the Kivy Framework. 
+    name='KivEnt.Core',
+    description='''A game engine for the Kivy Framework.
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
-    ext_modules=core_extensions,
-    cmdclass=cmdclass,
-    packages=[
-        'kivent_core',
-        'kivent_core.memory_handlers',
-        'kivent_core.rendering',
-        'kivent_core.managers',
-        'kivent_core.systems',
-        'kivent_core.uix'
-        ],
-    package_dir={'kivent_core': 'kivent_core'},
-    package_data={'kivent_core': [
-        '*.pxd', 
-        'memory_handlers/*.pxd',
-        'rendering/*.pxd',
-        'managers/*.pxd',
-        'systems/*.pxd',
-        'uix/*.pxd'
-        ]
-        },)
+    packages=find_packages(),
+    package_data={
+        '': ['*.pxd', '*.so']
+        },
+    setup_requires=['cython', 'setuptools.autocythonize'],
+    auto_cythonize={
+        "compile_args": compile_args,
+        "libraries": libraries,
+        "includes": kivy.get_includes()
+    }
+)

--- a/modules/cymunk/setup.py
+++ b/modules/cymunk/setup.py
@@ -1,94 +1,28 @@
-from os import environ, remove
-from os.path import dirname, join, isfile
-from distutils.core import setup
-from distutils.extension import Extension
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-    have_cython = True
-except ImportError:
-    have_cython = False
 import sys
-
-platform = sys.platform
-if platform == 'win32':
-	cstdarg = '-std=gnu99'
-else:
-	cstdarg = '-std=c99'
-
-do_clear_existing = True
-
+from setuptools import setup, find_packages
 import cymunk
-print(cymunk.get_includes())
 
-cymunk_modules = {
-    'kivent_cymunk.physics': ['kivent_cymunk/physics.pyx',],
-    'kivent_cymunk.interaction': ['kivent_cymunk/interaction.pyx',],
-}
-
-cymunk_modules_c = {
-    'kivent_cymunk.physics': ['kivent_cymunk/physics.c',],
-    'kivent_cymunk.interaction': ['kivent_cymunk/interaction.c',],
-}
-
-check_for_removal = [
-    'kivent_cymunk/physics.c',
-    'kivent_cymunk/interaction.c',
-
-    ]
-
-def build_ext(ext_name, files, include_dirs=cymunk.get_includes()):
-    return Extension(ext_name, files, include_dirs,
-        extra_compile_args=[cstdarg, '-ffast-math',])
-
-extensions = []
-cymunk_extensions = []
-cmdclass = {}
-
-def build_extensions_for_modules_cython(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name])
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return cythonize(ext_list)
-
-def build_extensions_for_modules(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name])
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return ext_list
-
-if have_cython:
-    if do_clear_existing:
-        for file_name in check_for_removal:
-            if isfile(file_name):
-                remove(file_name)
-    cymunk_extensions = build_extensions_for_modules_cython(
-        cymunk_extensions, cymunk_modules)
+if sys.platform == 'win32':
+    compile_args = ['-std=gnu99', '-ffast-math']
+    libraries = ['opengl32', 'glu32','glew32']
 else:
-    cymunk_extensions = build_extensions_for_modules(cymunk_extensions, 
-        cymunk_modules_c)
-
-
+    compile_args = ['-std=c99', '-ffast-math', "-w"]
+    libraries = []
 
 setup(
-    name='KivEnt Cymunk',
-    description='''A game engine for the Kivy Framework. 
+    name='KivEnt.Cymunk',
+    description='''A game engine for the Kivy Framework.
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
-    ext_modules=cymunk_extensions,
-    cmdclass=cmdclass,
-    packages=[
-        'kivent_cymunk',
-        ],
-    package_dir={'kivent_cymunk': 'kivent_cymunk'},
-    package_data={'kivent_cymunk': [
-            '*.pxd',
-            ]}
-        )
+    packages=find_packages(),
+    package_data={
+        '': ['*.pxd']
+    },
+    setup_requires=['cython', 'setuptools.autocythonize'],
+    auto_cythonize={
+        "compile_args": compile_args,
+        "libraries": libraries,
+        "includes": cymunk.get_includes()
+    }
+)

--- a/modules/cymunk/setup.py
+++ b/modules/cymunk/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='kovac1066@gmail.com',
     packages=find_packages(),
     package_data={
-        '': ['*.pxd']
+        '': ['*.pxd', '*.so']
     },
     setup_requires=['cython', 'setuptools.autocythonize'],
     auto_cythonize={

--- a/modules/particles/setup.py
+++ b/modules/particles/setup.py
@@ -1,102 +1,28 @@
-from os import environ, remove
-from os.path import dirname, join, isfile
-from distutils.core import setup
-from distutils.extension import Extension
-import kivy
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-    have_cython = True
-except ImportError:
-    have_cython = False
 import sys
+from setuptools import setup, find_packages
+import kivy
 
-platform = sys.platform
-if platform == 'win32':
-    cstdarg = '-std=gnu99'
+if sys.platform == 'win32':
+    compile_args = ['-std=gnu99', '-ffast-math']
     libraries = ['opengl32', 'glu32','glew32']
 else:
-    cstdarg = '-std=c99'
+    compile_args = ['-std=c99', '-ffast-math', '-w']
     libraries = []
 
-
-do_clear_existing = True
-
-
-
-particles_modules = {
-    'kivent_particles.particle': ['kivent_particles/particle.pyx'],
-    'kivent_particles.emitter': ['kivent_particles/emitter.pyx',],
-    'kivent_particles.particle_formats': ['kivent_particles/particle_formats.pyx',],
-    'kivent_particles.particle_renderers': ['kivent_particles/particle_renderers.pyx',],
-}
-
-particles_modules_c = {
-    'kivent_particles.particle': ['kivent_particles/particle.c',],
-    'kivent_particles.emitter': ['kivent_particles/emitter.c',],
-    'kivent_particles.particle_formats': ['kivent_particles/particle_formats.c',],
-    'kivent_particles.particle_renderers': ['kivent_particles/particle_renderers.c',],
-}
-
-check_for_removal = [
-    'kivent_particles/particle.c',
-    'kivent_particles.emitter.c',
-    'kivent_particles/particle_formats.c',
-    'kivent_particles/particle_renderers.c',
-
-    ]
-
-def build_ext(ext_name, files, include_dirs=[]):
-    return Extension(ext_name, files, include_dirs,
-        extra_compile_args=[cstdarg, '-ffast-math',],
-        libraries=libraries,)
-
-extensions = []
-particles_extensions = []
-cmdclass = {}
-
-def build_extensions_for_modules_cython(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-            include_dirs=kivy.get_includes())
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return cythonize(ext_list)
-
-def build_extensions_for_modules(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-            include_dirs=kivy.get_includes())
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return ext_list
-
-if have_cython:
-    if do_clear_existing:
-        for file_name in check_for_removal:
-            if isfile(file_name):
-                remove(file_name)
-    particles_extensions = build_extensions_for_modules_cython(
-        particles_extensions, particles_modules)
-else:
-    particles_extensions = build_extensions_for_modules(particles_extensions, 
-        particles_modules_c)
-
-
-
 setup(
-    name='KivEnt particles',
-    description='''A game engine for the Kivy Framework. 
+    name='KivEnt.Particles',
+    description='''A game engine for the Kivy Framework.
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
-    ext_modules=particles_extensions,
-    cmdclass=cmdclass,
-    packages=[
-        'kivent_particles',
-        ],
-    package_dir={'kivent_particles': 'kivent_particles'})
+    packages=find_packages(),
+    package_data={
+        '': ['*.pxd']
+    },
+    setup_requires=['cython', 'setuptools.autocythonize'],
+    auto_cythonize={
+        "compile_args": compile_args,
+        "libraries": libraries,
+        "includes": kivy.get_includes()
+    }
+)

--- a/modules/particles/setup.py
+++ b/modules/particles/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='kovac1066@gmail.com',
     packages=find_packages(),
     package_data={
-        '': ['*.pxd']
+        '': ['*.pxd', '*.so']
     },
     setup_requires=['cython', 'setuptools.autocythonize'],
     auto_cythonize={

--- a/modules/projectiles/setup.py
+++ b/modules/projectiles/setup.py
@@ -1,96 +1,28 @@
-from os import environ, remove
-from os.path import dirname, join, isfile
-from distutils.core import setup
-from distutils.extension import Extension
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-    have_cython = True
-except ImportError:
-    have_cython = False
 import sys
-
-platform = sys.platform
-if platform == 'win32':
-	cstdarg = '-std=gnu99'
-else:
-	cstdarg = '-std=c99'
-do_clear_existing = True
+from setuptools import setup, find_packages
 import cymunk
-print(cymunk.get_includes())
 
-noise_modules = {
-    'kivent_projectiles.projectiles': ['kivent_projectiles/projectiles.pyx'], 
-    'kivent_projectiles.weapons': ['kivent_projectiles/weapons.pyx'], 
-    'kivent_projectiles.combatstats': ['kivent_projectiles/combatstats.pyx'],
-    'kivent_projectiles.weapon_ai': ['kivent_projectiles/weapon_ai.pyx'],
-}
-
-noise_modules_c = {
-    'kivent_projectiles.weapons': ['kivent_projectiles/weapons.c'],
-    'kivent_projectiles.projectiles': ['kivent_projectiles/projectiles.c'],
-    'kivent_projectiles.combatstats': ['kivent_projectiles/combatstats.c'],
-    'kivent_projectiles.weapon_ai': ['kivent_projectiles/weapon_ai.c'],
-}
-
-check_for_removal = [
-    'kivent_projectiles/weapons.c',
-    'kivent_projectiles/projectiles.c',
-    'kivent_projectiles/combatstats.c',
-    'kivent_projectiles/weapon_ai.c',
-    ]
-
-
-
-def build_ext(ext_name, files, include_dirs=cymunk.get_includes()):
-    return Extension(
-        ext_name, files, include_dirs,
-        extra_compile_args=[cstdarg, '-ffast-math',],
-
-        )
-
-extensions = []
-noise_extensions = []
-cmdclass = {}
-
-def build_extensions_for_modules_cython(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name])
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return cythonize(ext_list)
-
-def build_extensions_for_modules(ext_list, modules):
-    ext_a = ext_list.append
-    for module_name in modules:
-        ext = build_ext(module_name, modules[module_name])
-        if environ.get('READTHEDOCS', None) == 'True':
-            ext.pyrex_directives = {'embedsignature': True}
-        ext_a(ext)
-    return ext_list
-
-if have_cython:
-    if do_clear_existing:
-        for file_name in check_for_removal:
-            if isfile(file_name):
-                remove(file_name)
-    noise_extensions = build_extensions_for_modules_cython(
-        noise_extensions, noise_modules)
+if sys.platform == 'win32':
+    compile_args = ['-std=gnu99', '-ffast-math']
+    libraries = ['opengl32', 'glu32','glew32']
 else:
-    noise_extensions = build_extensions_for_modules(noise_extensions, 
-        noise_modules_c)
+    compile_args = ['-std=c99', '-ffast-math', "-w"]
+    libraries = []
 
 setup(
-    name='KivEnt noise',
-    description='''A game engine for the Kivy Framework. 
+    name='KivEnt.Projectiles',
+    description='''A game engine for the Kivy Framework.
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
-    ext_modules=noise_extensions,
-    cmdclass=cmdclass,
-    packages=[
-        'kivent_projectiles',
-        ],
-    package_dir={'kivent_projectiles': 'kivent_projectiles'})
+    packages=find_packages(),
+    package_data={
+        '': ['*.pxd']
+        },
+    setup_requires=['cython', 'setuptools.autocythonize'],
+    auto_cythonize={
+        "compile_args": compile_args,
+        "libraries": libraries,
+        "includes": cymunk.get_includes()
+    }
+)

--- a/modules/projectiles/setup.py
+++ b/modules/projectiles/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='kovac1066@gmail.com',
     packages=find_packages(),
     package_data={
-        '': ['*.pxd']
+        '': ['*.pxd', '*.so']
         },
     setup_requires=['cython', 'setuptools.autocythonize'],
     auto_cythonize={


### PR DESCRIPTION
There is alot of boilerplate code in the modules setup.py. This shores them up with setuptools.autocythonize.

Simply put, it leverages setuptools find_packages to find all the locations where your pyx files could live, and autogenerates disutils Extension objects for them. This is then appended into setup keyword arg ext_modules, but first if the files need cythonizing this is done.

This also exposes a cythonize command so you can do a full "clean" build of the cython files.

Since this is an addon to ext_modules, you can still define other Extensions if needs be (if you need to control the includes or compile arg per extension, this is purely to remove all the boilerplate listing of files, extensions and packages, and is to cover the 90% of standard use cases for compiling cython files.

This will also help kivent in the future with its packaging, as It would be nice to eventually breakout each module into its own repo, and have each be pip installable, leveraging namespace packaging, similar to the zope framework, but this is something i'll save for a different pull request.