### PR TITLE
No dirname in cymunk setup.py

### DIFF
--- a/modules/cymunk/setup.py
+++ b/modules/cymunk/setup.py
@@ -94,7 +94,7 @@ check_for_removal = [
 
 import pkgutil
 loader = pkgutil.get_loader("cymunk")
-cymunk_dirname = dirname(loader.path if hasattr(loader, 'path') else loader.filename)
+cymunk_dirname = loader.path if hasattr(loader, 'path') else loader.filename
 
 def build_ext(ext_name, files, include_dirs=[cymunk_dirname]):
     return Extension(ext_name, files, global_include_dirs + include_dirs,


### PR DESCRIPTION
Use of dirname in setup.py makes such error for me:

```
maho@dlaptop:~/workspace/khamster/src/.binpackages/kivent/modules/cymunk$ python setup.py build_ext
Compiling kivent_cymunk/interaction.pyx because it changed.
Compiling kivent_cymunk/physics.pyx because it changed.
[1/2] Cythonizing kivent_cymunk/interaction.pyx
warning: kivent_cymunk/interaction.pyx:549:20: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: kivent_cymunk/interaction.pyx:549:27: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: kivent_cymunk/interaction.pyx:728:20: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: kivent_cymunk/interaction.pyx:728:34: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: kivent_cymunk/interaction.pyx:758:20: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: kivent_cymunk/interaction.pyx:758:27: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: kivent_cymunk/interaction.pyx:758:43: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
[2/2] Cythonizing kivent_cymunk/physics.pyx
running build_ext
building 'kivent_cymunk.interaction' extension
creating build/temp.linux-x86_64-2.7
creating build/temp.linux-x86_64-2.7/kivent_cymunk
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/home/maho/.virtualenvs/khamster/lib/python2.7/site-packages -I/usr/include/python2.7 -c kivent_cymunk/interaction.c -o build/temp.linux-x86_64-2.7/kivent_cymunk/interaction.o -std=gnu99 -ffast-math
kivent_cymunk/interaction.c:283:31: fatal error: chipmunk/chipmunk.h: Nie ma takiego pliku ani katalogu
 #include "chipmunk/chipmunk.h"
```

this PR fixes it. 