### PR TITLE
- schedule texture key change to next update() iteration

### DIFF
--- a/modules/core/kivent_core/gameworld.pyx
+++ b/modules/core/kivent_core/gameworld.pyx
@@ -131,6 +131,7 @@ class GameWorld(Widget):
         super(GameWorld, self).__init__(**kwargs)
         self.states = {}
         self.state_callbacks = {}
+        self.before_update_callbacks = []
         self.managers = {}
         self.entity_manager = None
         self.entities = None
@@ -496,6 +497,9 @@ class GameWorld(Widget):
         entity.load_order = []
         entity_manager.remove_entity(entity_id)
 
+    def schedule_once(self, fn):
+        self.before_update_callbacks.append(fn)
+
     def update(self, dt):
         '''
         Args:
@@ -510,6 +514,11 @@ class GameWorld(Widget):
         cdef SystemManager system_manager = self.system_manager
         cdef list systems = system_manager.systems
         cdef GameSystem system
+
+        for f in self.before_update_callbacks:
+            f()
+        self.before_update_callbacks = []
+
         for system_index in system_manager._update_order:
             system = systems[system_index]
             if system.updateable and not system.paused:


### PR DESCRIPTION
This commit fixes problem with flickering. 

Testcase - https://github.com/mahomahomaho/kivent-memory-issue-case 

Before this pull request:
  0. - frame is rendered properly
  1. - 1sec  later, texture_set is set to next texture, frame gets blank
  2. - 1sec later, frame is rendered properly
  3. goto 0.

after pull request, whole texture_set is scheduled and executed in the beginning of Gameworld.update()

It's very likely that coding style is against your coding style, then please give guidelines or fix yourself.