### PR TITLE
Get tile index feature

### DIFF
--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -4,6 +4,7 @@ from kivent_core.rendering.animation cimport FrameList
 from kivent_core.managers.resource_managers import texture_manager
 from kivent_core.memory_handlers.block cimport MemoryBlock
 from kivent_maps.map_manager cimport MapManager
+import math
 
 
 cdef class LayerTile:
@@ -688,6 +689,24 @@ cdef class IsometricTileMap(TileMap):
         y = h - th/2 - y
 
         return (x, y)
+
+    def get_tile_index(self, pixel_x, pixel_y):
+        w, h = self.size_on_screen
+        tw, th = self.tile_size
+
+        m = float(th)/tw
+        cos = 1/math.sqrt(1 + m*m)
+        sin = math.sqrt(1 - cos*cos)
+        side = th/(2*sin)
+        pixel_y = h - pixel_y
+        pixel_x -= w/2
+
+        new_u = (pixel_x/(2*cos) + pixel_y/(2*sin))
+        new_v = (pixel_y/(2*sin) - pixel_x/(2*cos))
+        col = int(new_u/side)
+        row = int(new_v/side)
+
+        return (col, row)
 
     property size_on_screen:
         def __get__(self):

--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -596,13 +596,12 @@ cdef class StaggeredTileMap(TileMap):
         sa = self._stagger_axis
         si = self._stagger_index
 
+        m = float(th)/tw
         col_shifted = int((pixel_x - tw/2)/tw)
         col_non_shifted = int(pixel_x/tw)
-
         row_shifted = int((h - pixel_y - th/2)/th)
         row_non_shifted = int((h - pixel_y)/th)
 
-        m = float(th)/float(tw)
         rel_x_g = abs(pixel_x - col_non_shifted*tw)
         rel_x_r = abs(pixel_x - col_shifted*tw - tw/2)
 
@@ -625,7 +624,7 @@ cdef class StaggeredTileMap(TileMap):
                 col = col_non_shifted
                 row = row_shifted*2+1 if si else row_non_shifted*2
 
-        if (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
+        elif (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
                 and rel_y_r < m*rel_x_r + th/2 and rel_y_r > (-1)*m*rel_x_r + th/2):
             if sa:
                 row = row_non_shifted if si else row_shifted
@@ -633,30 +632,7 @@ cdef class StaggeredTileMap(TileMap):
             else:
                 col = col_shifted
                 row = row_non_shifted*2 if si else row_shifted*2+1
-        '''
-        else:
-            m = float(th)/float(tw)
 
-            rel_x_g = abs(pixel_x - col_non_shifted*tw)
-            rel_x_r = abs(pixel_x - col_shifted*tw - tw/2)
-
-            if si:
-                rel_y_g = abs(h - pixel_y - row_shifted*th - 1.5*th)
-                rel_y_r = abs(h - pixel_y - row_non_shifted*th - th)
-            else:
-                rel_y_r = abs(h - pixel_y - row_shifted*th - 1.5*th)
-                rel_y_g = abs(h - pixel_y - row_non_shifted*th - th)
-
-            if (rel_y_g > m*rel_x_g - th/2 and rel_y_g < (-1)*m*rel_x_g + 3*(th/2)
-                    and rel_y_g < m*rel_x_g + th/2 and rel_y_g > (-1)*m*rel_x_g + th/2):
-                col = col_non_shifted
-                row = row_shifted*2+1 if si else row_non_shifted*2
-
-            if (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
-                    and rel_y_r < m*rel_x_r + th/2 and rel_y_r > (-1)*m*rel_x_r + th/2):
-                col = col_shifted
-                row = row_non_shifted*2 if si else row_shifted*2+1
-        '''
         return (col,row)
 
     property size_on_screen:
@@ -728,96 +704,38 @@ cdef class HexagonalTileMap(StaggeredTileMap):
         ts = self.hex_side_length
 
         if sa:
-            c = (tw - ts)/2.0
-            box_col = int(pixel_x/(ts + c))
-            is_box_col_odd = (box_col%2 == 1)
+            c = (tw - ts)/2
+            m = float(th/2)/c
+            col_shifted = int((pixel_x - ts - c)/(tw + ts))
+            col_non_shifted = int(pixel_x/(tw + ts))
 
-            rel_box_x = pixel_x - box_col*(ts + c)
+            row_shifted = int((h - pixel_y - th/2)/th)
+            row_non_shifted = int((h - pixel_y)/th)
 
-            if (si and is_box_col_odd) or ((not si) and (not is_box_col_odd)):
-                box_row = int((h - pixel_y)/th)
-                rel_box_y = abs(h - pixel_y - box_row*th - th)
-            else:
-                box_row = int((h - pixel_y - th/2.0)/th)
-                rel_box_y = abs(h - pixel_y - box_row*th - th/2.0 - th)
-            '''
+            rel_x_g = abs(pixel_x - col_non_shifted*(tw+ts))
+            rel_x_r = abs(pixel_x - col_shifted*(tw + ts) - (ts + c))
+            col = col_shifted
+            row = row_shifted
+
             if si:
-                if is_box_col_odd:
-                    box_row = int((h - pixel_y)/th)
-                    rel_box_y = h - pixel_y - box_row*th
-                else:
-                    box_row = int((h - pixel_y - th/2)/th)
-                    rel_box_y = h - pixel_y - box_row*th - th/2
+                rel_y_g = abs(h - pixel_y - row_shifted*th - 1.5*th)
+                rel_y_r = abs(h - pixel_y - row_non_shifted*th - th)
             else:
-                if is_box_col_odd:
-                    box_row = int((h - pixel_y - th/2)/th)
-                    rel_box_y = h - pixel_y - box_row*th -th/2
-                else:
-                    box_row = int((h - pixel_y)/th)
-                    rel_box_y = h - pixel_y - box_row*th
-            '''
-            # m = math.tan(math.pi/3)   # positive slope of the slanted line
-            m = th/(2.0*c)
-            row = box_row
-            col = box_col
-            """
-            if rel_box_y == 0 or rel_box_y == th:
-                col = box_col - 1
-                if ((si and col%2 == 0 ) or ((not si) and col%2 == 1)):
-                    row = box_row - 1
-                else:
-                    row = box_row
-            
-                '''
-                if si:
-                    if col%2 == 0:
-                        row = box_row - 1
-                    else:
-                        row = box_row
-                else:
-                    if col%2 == 0:
-                        row = box_row
-                    else:
-                        row = box_row - 1
-                '''
-            """
-            if rel_box_y > m*rel_box_x + th/2.0:
-                col = box_col - 1
-                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
-                    row = box_row - 1
-                else:
-                    row = box_row
-                '''
-                if si:
-                    if col%2 == 0:
-                        row = box_row - 1
-                    else:
-                        row = box_row
-                else:
-                    if col%2 == 0:
-                        row = box_row
-                    else:
-                        row = box_row - 1
-                '''
-            elif rel_box_y < -1*m*rel_box_x + th/2.0:
-                col = box_col - 1
-                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
-                    row = box_row
-                else:
-                    row = box_row + 1
-                '''
-                if si:
-                    if col%2 == 0:
-                        row = box_row
-                    else:
-                        row = box_row + 1
-                else:
-                    if col% 2 == 0:
-                        row = box_row + 1
-                    else:
-                        row = box_row
-                '''
-            #return (col, row)
+                rel_y_r = abs(h - pixel_y - row_shifted*th - 1.5*th)
+                rel_y_g = abs(h - pixel_y - row_non_shifted*th - th)
+
+            if rel_y_g > m*rel_x_g - m*(ts+c) and rel_y_g < -1*m*rel_x_g + th + m*(ts+c) \
+                    and rel_y_g < th and rel_y_g > 0 and rel_y_g < m*rel_x_g + th/2 \
+                    and rel_y_g > -1*m*rel_x_g + th/2:
+                col = col_non_shifted*2
+                row = row_shifted if si else row_non_shifted
+
+            elif rel_y_r > m*rel_x_r - m*(ts+c) and rel_y_r < -1*m*rel_x_r + th + m*(ts + c) \
+                    and rel_y_r < th and rel_y_r > 0 and rel_y_r < m*rel_x_r + th/2 \
+                    and rel_y_r > -1*m*rel_x_r + th/2:
+                col = col_shifted*2 + 1
+                row = row_non_shifted if si else row_shifted
+        """
         else:
             row = int((h - pixel_y)/th)
             if si:
@@ -830,8 +748,9 @@ cdef class HexagonalTileMap(StaggeredTileMap):
                     col = int(pixel_x/tw)
                 else:
                     col = int(pixel_x - tw/2)/tw
+        """
         return (col, row)
-
+        
     property size_on_screen:
         def __get__(self):
             sx, sy = self.size_x, self.size_y
@@ -879,11 +798,13 @@ cdef class IsometricTileMap(TileMap):
         cos = 1/math.sqrt(1 + m*m)
         sin = math.sqrt(1 - cos*cos)
         side = th/(2*sin)
+
         pixel_y = h - pixel_y
         pixel_x -= w/2
 
         new_u = (pixel_x/(2*cos) + pixel_y/(2*sin))
         new_v = (pixel_y/(2*sin) - pixel_x/(2*cos))
+
         col = int(new_u/side)
         row = int(new_v/side)
 

--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -651,6 +651,86 @@ cdef class HexagonalTileMap(StaggeredTileMap):
 
         return (x, y)
 
+    def get_tile_index(self, pixel_x, pixel_y):
+        w, h = self.size_on_screen
+        tw, th = self.tile_size
+        sa = self._stagger_axis
+        si = self._stagger_index
+        ts = self.hex_side_length
+
+        if sa:
+            c = (tw - ts)/2.0
+            box_col = int(pixel_x/(ts + c))
+            is_box_col_odd = (box_col%2 == 1)
+
+            rel_box_x = pixel_x - box_col*(ts + c)
+
+            if (si and is_box_col_odd) or ((not si) and (not is_box_col_odd)):
+                box_row = int((h - pixel_y - th/2)/th)
+                rel_box_y = h - pixel_y - th/2 - box_row*th
+            else:
+                box_row = int((h - pixel_y)/th)
+                rel_box_y = h - pixel_y - box_row*th
+            '''
+            if si:
+                if is_box_col_odd:
+                    box_row = int((h - pixel_y - th/2)/th)
+                    rel_box_y = h - pixel_y - box_row*th - th/2
+                else:
+                    box_row = int((h - pixel_y)/th)
+                    rel_box_y = h - pixel_y - box_row*th
+            else:
+                if is_box_col_odd:
+                    box_row = int((h - pixel_y)/th)
+                    rel_box_y = h - pixel_y - box_row*th
+                else:
+                    box_row = int((h - pixel_y-th/2)/th)
+                    rel_box_y = h - pixel_y - box_row*th - th/2
+            '''
+            m = math.tan(math.pi/3)   # positive slope of the slanted line
+            row = box_row
+            col = box_col
+            if rel_box_y == 0 or rel_box_y == th:
+                print (row, col)
+                pass
+
+            elif rel_box_y > m*rel_box_x + c*m:
+                col = box_col - 1
+                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
+                    row = box_row + 1
+                else:
+                    row = box_row
+                '''
+                if si:
+                    if col%2 == 0:
+                        row = box_row + 1
+                    else:
+                        row = box_row
+                else:
+                    if col%2 == 0:
+                        row = box_row
+                    else:
+                        row = box_row + 1
+                '''
+            elif rel_box_y < -1*m*rel_box_x + c*m:
+                col = box_col - 1
+                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
+                    row = box_row
+                else:
+                    row = box_row - 1
+                '''
+                if si:
+                    if col%2 == 0:
+                        row = box_row
+                    else:
+                        row = box_row - 1
+                else:
+                    if col% 2 == 0:
+                        row = box_row - 1
+                    else:
+                        row = box_row
+                '''
+            return (col, row)
     property size_on_screen:
         def __get__(self):
             sx, sy = self.size_x, self.size_y

--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -601,27 +601,39 @@ cdef class StaggeredTileMap(TileMap):
 
         row_shifted = int((h - pixel_y - th/2)/th)
         row_non_shifted = int((h - pixel_y)/th)
-        col_r=2
-        col_g=2
-        if sa:
-            center_x_g = abs(pixel_x - col_g*tw - tw/2)
-            center_x_r = abs(pixel_x - col_r*tw - tw)
 
-            if si:
-                center_y_g = abs(h - pixel_y - th - row_shifted*th)
-                center_y_r = abs(h - pixel_y - th/2 - row_non_shifted*th)
-            else:
-                center_y_r = abs(h - pixel_y - th - row_shifted*th)
-                center_y_g = abs(h - pixel_y - th/2 - row_non_shifted*th)
+        m = float(th)/float(tw)
+        rel_x_g = abs(pixel_x - col_non_shifted*tw)
+        rel_x_r = abs(pixel_x - col_shifted*tw - tw/2)
 
-            if (pow(center_x_g, 2) + pow(center_y_g, 2)) < (pow(center_x_r, 2) + pow(center_y_r, 2)):
-                col = col_g
+        col = col_shifted
+        row = row_shifted
+
+        if si:
+            rel_y_g = abs(h - pixel_y - row_shifted*th - 1.5*th)
+            rel_y_r = abs(h - pixel_y - row_non_shifted*th - th)
+        else:
+            rel_y_r = abs(h - pixel_y - row_shifted*th - 1.5*th)
+            rel_y_g = abs(h - pixel_y - row_non_shifted*th - th)
+
+        if (rel_y_g > m*rel_x_g - th/2 and rel_y_g < (-1)*m*rel_x_g + 3*(th/2)
+                and rel_y_g < m*rel_x_g + th/2 and rel_y_g > (-1)*m*rel_x_g + th/2):
+            if sa:
                 row = row_shifted if si else row_non_shifted
+                col = col_non_shifted*2
             else:
-                col = col_r
-                row = row_non_shifted if si else row_shifted
-            return (col, row)
+                col = col_non_shifted
+                row = row_shifted*2+1 if si else row_non_shifted*2
 
+        if (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
+                and rel_y_r < m*rel_x_r + th/2 and rel_y_r > (-1)*m*rel_x_r + th/2):
+            if sa:
+                row = row_non_shifted if si else row_shifted
+                col = col_shifted*2+1
+            else:
+                col = col_shifted
+                row = row_non_shifted*2 if si else row_shifted*2+1
+        '''
         else:
             m = float(th)/float(tw)
 
@@ -629,22 +641,23 @@ cdef class StaggeredTileMap(TileMap):
             rel_x_r = abs(pixel_x - col_shifted*tw - tw/2)
 
             if si:
-                rel_y_g = abs(h - pixel_y - row_non_shifted*th)
-                rel_y_r = abs(h - pixel_y - row_shifted*th - th/2)
+                rel_y_g = abs(h - pixel_y - row_shifted*th - 1.5*th)
+                rel_y_r = abs(h - pixel_y - row_non_shifted*th - th)
             else:
-                rel_y_g = abs(h - pixel_y - row_shifted*th - th/2)
-                rel_y_r = abs(h - pixel_y - row_non_shifted*th)
+                rel_y_r = abs(h - pixel_y - row_shifted*th - 1.5*th)
+                rel_y_g = abs(h - pixel_y - row_non_shifted*th - th)
 
             if (rel_y_g > m*rel_x_g - th/2 and rel_y_g < (-1)*m*rel_x_g + 3*(th/2)
                     and rel_y_g < m*rel_x_g + th/2 and rel_y_g > (-1)*m*rel_x_g + th/2):
                 col = col_non_shifted
-                row = row_non_shifted*2 if si else row_shifted*2+1
+                row = row_shifted*2+1 if si else row_non_shifted*2
 
             if (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
                     and rel_y_r < m*rel_x_r + th/2 and rel_y_r > (-1)*m*rel_x_r + th/2):
                 col = col_shifted
-                row = row_shifted*2+1 if si else row_non_shifted*2
-            return (col,row)
+                row = row_non_shifted*2 if si else row_shifted*2+1
+        '''
+        return (col,row)
 
     property size_on_screen:
         def __get__(self):

--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -590,6 +590,62 @@ cdef class StaggeredTileMap(TileMap):
 
         return (x, y)
 
+    def get_tile_index(self, pixel_x, pixel_y):
+        w, h = self.size_on_screen
+        tw, th = self.tile_size
+        sa = self._stagger_axis
+        si = self._stagger_index
+
+        col_shifted = int((pixel_x - tw/2)/tw)
+        col_non_shifted = int(pixel_x/tw)
+
+        row_shifted = int((h - pixel_y - th/2)/th)
+        row_non_shifted = int((h - pixel_y)/th)
+        col_r=2
+        col_g=2
+        if sa:
+            center_x_g = abs(pixel_x - col_g*tw - tw/2)
+            center_x_r = abs(pixel_x - col_r*tw - tw)
+
+            if si:
+                center_y_g = abs(h - pixel_y - th - row_shifted*th)
+                center_y_r = abs(h - pixel_y - th/2 - row_non_shifted*th)
+            else:
+                center_y_r = abs(h - pixel_y - th - row_shifted*th)
+                center_y_g = abs(h - pixel_y - th/2 - row_non_shifted*th)
+
+            if (pow(center_x_g, 2) + pow(center_y_g, 2)) < (pow(center_x_r, 2) + pow(center_y_r, 2)):
+                col = col_g
+                row = row_shifted if si else row_non_shifted
+            else:
+                col = col_r
+                row = row_non_shifted if si else row_shifted
+            return (col, row)
+
+        else:
+            m = float(th)/float(tw)
+
+            rel_x_g = abs(pixel_x - col_non_shifted*tw)
+            rel_x_r = abs(pixel_x - col_shifted*tw - tw/2)
+
+            if si:
+                rel_y_g = abs(h - pixel_y - row_non_shifted*th)
+                rel_y_r = abs(h - pixel_y - row_shifted*th - th/2)
+            else:
+                rel_y_g = abs(h - pixel_y - row_shifted*th - th/2)
+                rel_y_r = abs(h - pixel_y - row_non_shifted*th)
+
+            if (rel_y_g > m*rel_x_g - th/2 and rel_y_g < (-1)*m*rel_x_g + 3*(th/2)
+                    and rel_y_g < m*rel_x_g + th/2 and rel_y_g > (-1)*m*rel_x_g + th/2):
+                col = col_non_shifted
+                row = row_non_shifted*2 if si else row_shifted*2+1
+
+            if (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
+                    and rel_y_r < m*rel_x_r + th/2 and rel_y_r > (-1)*m*rel_x_r + th/2):
+                col = col_shifted
+                row = row_shifted*2+1 if si else row_non_shifted*2
+            return (col,row)
+
     property size_on_screen:
         def __get__(self):
             sx, sy = self.size_x, self.size_y
@@ -666,71 +722,103 @@ cdef class HexagonalTileMap(StaggeredTileMap):
             rel_box_x = pixel_x - box_col*(ts + c)
 
             if (si and is_box_col_odd) or ((not si) and (not is_box_col_odd)):
-                box_row = int((h - pixel_y - th/2)/th)
-                rel_box_y = h - pixel_y - th/2 - box_row*th
-            else:
                 box_row = int((h - pixel_y)/th)
-                rel_box_y = h - pixel_y - box_row*th
+                rel_box_y = abs(h - pixel_y - box_row*th - th)
+            else:
+                box_row = int((h - pixel_y - th/2.0)/th)
+                rel_box_y = abs(h - pixel_y - box_row*th - th/2.0 - th)
             '''
             if si:
                 if is_box_col_odd:
+                    box_row = int((h - pixel_y)/th)
+                    rel_box_y = h - pixel_y - box_row*th
+                else:
                     box_row = int((h - pixel_y - th/2)/th)
                     rel_box_y = h - pixel_y - box_row*th - th/2
-                else:
-                    box_row = int((h - pixel_y)/th)
-                    rel_box_y = h - pixel_y - box_row*th
             else:
                 if is_box_col_odd:
+                    box_row = int((h - pixel_y - th/2)/th)
+                    rel_box_y = h - pixel_y - box_row*th -th/2
+                else:
                     box_row = int((h - pixel_y)/th)
                     rel_box_y = h - pixel_y - box_row*th
-                else:
-                    box_row = int((h - pixel_y-th/2)/th)
-                    rel_box_y = h - pixel_y - box_row*th - th/2
             '''
-            m = math.tan(math.pi/3)   # positive slope of the slanted line
+            # m = math.tan(math.pi/3)   # positive slope of the slanted line
+            m = th/(2.0*c)
             row = box_row
             col = box_col
+            """
             if rel_box_y == 0 or rel_box_y == th:
-                print (row, col)
-                pass
-
-            elif rel_box_y > m*rel_box_x + c*m:
                 col = box_col - 1
-                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
-                    row = box_row + 1
-                else:
-                    row = box_row
-                '''
-                if si:
-                    if col%2 == 0:
-                        row = box_row + 1
-                    else:
-                        row = box_row
-                else:
-                    if col%2 == 0:
-                        row = box_row
-                    else:
-                        row = box_row + 1
-                '''
-            elif rel_box_y < -1*m*rel_box_x + c*m:
-                col = box_col - 1
-                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
-                    row = box_row
-                else:
+                if ((si and col%2 == 0 ) or ((not si) and col%2 == 1)):
                     row = box_row - 1
+                else:
+                    row = box_row
+            
                 '''
                 if si:
+                    if col%2 == 0:
+                        row = box_row - 1
+                    else:
+                        row = box_row
+                else:
                     if col%2 == 0:
                         row = box_row
                     else:
                         row = box_row - 1
+                '''
+            """
+            if rel_box_y > m*rel_box_x + th/2.0:
+                col = box_col - 1
+                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
+                    row = box_row - 1
+                else:
+                    row = box_row
+                '''
+                if si:
+                    if col%2 == 0:
+                        row = box_row - 1
+                    else:
+                        row = box_row
+                else:
+                    if col%2 == 0:
+                        row = box_row
+                    else:
+                        row = box_row - 1
+                '''
+            elif rel_box_y < -1*m*rel_box_x + th/2.0:
+                col = box_col - 1
+                if ((si and col%2 == 0) or ((not si) and col%2 == 1)):
+                    row = box_row
+                else:
+                    row = box_row + 1
+                '''
+                if si:
+                    if col%2 == 0:
+                        row = box_row
+                    else:
+                        row = box_row + 1
                 else:
                     if col% 2 == 0:
-                        row = box_row - 1
+                        row = box_row + 1
                     else:
                         row = box_row
                 '''
-            return (col, row)
+            #return (col, row)
+        else:
+            row = int((h - pixel_y)/th)
+            if si:
+                if row%2 == 0:
+                    col = int(pixel_x - tw/2)/tw
+                else:
+                    col = int(pixel_x/tw)
+            else:
+                if row%2 == 0:
+                    col = int(pixel_x/tw)
+                else:
+                    col = int(pixel_x - tw/2)/tw
+        return (col, row)
+
     property size_on_screen:
         def __get__(self):
             sx, sy = self.size_x, self.size_y

--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -398,6 +398,24 @@ cdef class TileMap:
 
         return (i * tw + tw/2, h - j * th - th/2)
 
+    def get_tile_index(self, pixel_x, pixel_y):
+        '''
+        Calculates the grid position(index) of the tile at a given pixel 
+        position
+
+        Args:
+            pixel_x: horizontal pixel position of tile from left edge
+
+            pixel_y: vertical pixel position of tile from its top edge
+
+        Return:
+            (unsigned i, unsigned j): col and row of the tile.
+        '''
+        w, h = self.size_on_screen
+        tw, th = self.tile_size
+
+        return (int(pixel_x/tw), int((h - pixel_y)/th))
+
     property tiles:
         def __get__(self):
             tile_list = []

--- a/modules/maps/kivent_maps/map_data.pyx
+++ b/modules/maps/kivent_maps/map_data.pyx
@@ -607,9 +607,6 @@ cdef class StaggeredTileMap(TileMap):
         rel_x_g = abs(pixel_x - col_non_shifted*tw)
         rel_x_r = abs(pixel_x - col_shifted*tw - tw/2)
 
-        col = 0         # set only in case pixel lies on the boundary
-        row = 0
-
         if si:
             rel_y_g = abs(h - pixel_y - row_shifted*th - 1.5*th)
             rel_y_r = abs(h - pixel_y - row_non_shifted*th - th)
@@ -620,7 +617,8 @@ cdef class StaggeredTileMap(TileMap):
         # checking whether the point (pixel_x, pixel_y) lies inside the
         # tile by using the line equations of the four bounding lines.
         if (rel_y_g > m*rel_x_g - th/2 and rel_y_g < (-1)*m*rel_x_g + 3*(th/2)
-                and rel_y_g < m*rel_x_g + th/2 and rel_y_g > (-1)*m*rel_x_g + th/2):
+                and rel_y_g < m*rel_x_g + th/2
+                and rel_y_g > (-1)*m*rel_x_g + th/2):
             if sa:
                 row = row_shifted if si else row_non_shifted
                 col = col_non_shifted*2
@@ -628,8 +626,10 @@ cdef class StaggeredTileMap(TileMap):
                 col = col_non_shifted
                 row = row_shifted*2+1 if si else row_non_shifted*2
 
-        elif (rel_y_r > m*rel_x_r - th/2 and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
-                and rel_y_r < m*rel_x_r + th/2 and rel_y_r > (-1)*m*rel_x_r + th/2):
+        elif (rel_y_r > m*rel_x_r - th/2
+                and rel_y_r < (-1)*m*rel_x_r + 3*(th/2)
+                and rel_y_r < m*rel_x_r + th/2
+                and rel_y_r > (-1)*m*rel_x_r + th/2):
             if sa:
                 row = row_non_shifted if si else row_shifted
                 col = col_shifted*2+1
@@ -707,8 +707,6 @@ cdef class HexagonalTileMap(StaggeredTileMap):
         si = self._stagger_index
         ts = self.hex_side_length
 
-        col = 0     # set only in case pixel lies on the boundary
-        row = 0
         if sa:
             c = (tw - ts)/2
             m = float(th/2)/c
@@ -730,15 +728,15 @@ cdef class HexagonalTileMap(StaggeredTileMap):
 
             # check if the pixel (pixel_x, pixel_y) lies inside the tile by
             # using the line equations of all bounding sides.
-            if rel_y_g > m*rel_x_g - m*(ts+c) and rel_y_g < -1*m*rel_x_g + th + m*(ts+c) \
-                    and rel_y_g < th and rel_y_g > 0 and rel_y_g < m*rel_x_g + th/2 \
-                    and rel_y_g > -1*m*rel_x_g + th/2:
+            if (rel_y_g >= m*rel_x_g - m*(ts+c)
+                    and rel_y_g <= (-1)*m*rel_x_g + th + m*(ts+c)
+                    and rel_y_g <= th and rel_y_g >= 0
+                    and rel_y_g <= m*rel_x_g + th/2
+                    and rel_y_g >= (-1)*m*rel_x_g + th/2):
                 col = col_non_shifted*2
                 row = row_shifted if si else row_non_shifted
 
-            elif rel_y_r > m*rel_x_r - m*(ts+c) and rel_y_r < -1*m*rel_x_r + th + m*(ts + c) \
-                    and rel_y_r < th and rel_y_r > 0 and rel_y_r < m*rel_x_r + th/2 \
-                    and rel_y_r > -1*m*rel_x_r + th/2:
+            else:
                 col = col_shifted*2 + 1
                 row = row_non_shifted if si else row_shifted
 
@@ -751,7 +749,7 @@ cdef class HexagonalTileMap(StaggeredTileMap):
             row_shifted = int((h - pixel_y - (ts+c))/(th + ts))
 
             rel_y_g = abs(h - pixel_y - row_non_shifted*(th + ts) - (th + ts))
-            rel_y_r = abs(h - pixel_y - row_shifted*(th + ts) - (ts + c) - (th + ts))
+            rel_y_r = abs(h - pixel_y - (row_shifted + 1)*(th + ts) - (ts + c))
 
             if si:
                 rel_x_g = abs(pixel_x - tw/2 - col_shifted*tw)
@@ -759,14 +757,15 @@ cdef class HexagonalTileMap(StaggeredTileMap):
             else:
                 rel_x_g = abs(pixel_x - col_non_shifted*tw)
                 rel_x_r = abs(pixel_x - tw/2 - col_shifted*tw)
-            
-            if rel_y_g > -1*m*rel_x_g + (ts + c) and rel_y_g > m*rel_x_g + (ts - c) \
-                    and rel_y_g < m*rel_x_g + (2*ts + c) and rel_y_g < -1*m*rel_x_g + (2*ts + 3*c):
+
+            if (rel_y_g >= -1*m*rel_x_g + (ts + c)
+                    and rel_y_g >= m*rel_x_g + (ts - c)
+                    and rel_y_g <= m*rel_x_g + (2*ts + c)
+                    and rel_y_g <= -1*m*rel_x_g + (2*ts + 3*c)):
                 col = col_shifted if si else col_non_shifted
                 row = row_non_shifted*2
 
-            elif rel_y_r > -1*m*rel_x_r + (ts + c) and rel_y_r > m*rel_x_r + (ts - c) \
-                    and rel_y_r < m*rel_x_r + (2*ts + c) and rel_y_r < -1*m*rel_x_r + (2*ts + 3*c):
+            else:
                 col = col_non_shifted if si else col_shifted
                 row = row_shifted*2+1
 


### PR DESCRIPTION
Well this pr adds get-tile-index feature for orthogonal, isometric, staggered(isometric) and hexagonal maps. That is , given a pixel value of any point it returns tile index in which the pixel lies.I have explained below  a bit about the method which I followed to get the tile index from pixel-values for all maps except orthogonal maps(since it is straight-forward).

For isometric map I have transformed the x-y co-ordinates to the co-ordinates parallel to the sides of the isometric map and then followed the same procedure used in orthogonal maps.
For isometric_staggered maps , I have surrounded each tile with rectangle and then found out the rectangular tile in which the pixel lies and then calculated the relative co-ordinates of the pixel w.r.t the box and finally used line equations to find whether that pixel is contained within the tile bounded by  rectangular-box.Below tilemap shows the green and red group of tiles which I have denoted in my code  as r and g.
![isometric2](https://cloud.githubusercontent.com/assets/18272074/22593531/04e28ba2-ea45-11e6-8645-ea865a5c1625.png)

For hexagonal maps , I have again used rectangular boxes bounding the hexagons. Found out the box in which it lies , then calculated the relative-coordinates of the pixel w.r.t the box and then using line equations confirmed whether the point lies within the hexagon or not. Well for hexagon maps  with sa = False , I have taken the map to be the below one and not the one being generated in Tiled. and hence it is untested but still I have twice checked the calculations behind it.Below tilemap is the one which corresponds to sa=False.
![hexagonal](https://cloud.githubusercontent.com/assets/18272074/22593607/63cb0388-ea45-11e6-8923-fc6920703379.png)