### PR TITLE
Svn pathinfo and example

### DIFF
--- a/examples/16_svg_phys_objects/main.py
+++ b/examples/16_svg_phys_objects/main.py
@@ -89,7 +89,7 @@ class TestGame(Widget):
             pos = (randint(0, 200), randint(0, 200))
             #info, pos = self.normalize_info(info)
 
-            Logger.debug("adding object with title/element_id=%s/%s and pos=%s", info.title, info.element_id, pos)
+            Logger.debug("adding object with title/element_id=%s/%s and desc=%s", info.title, info.element_id, info.description)
             model_name = mm.load_model_from_model_info(info, data['svg_name'])
 
             poly_shape = {

--- a/examples/16_svg_phys_objects/main.py
+++ b/examples/16_svg_phys_objects/main.py
@@ -51,6 +51,8 @@ class TestGame(Widget):
             Logger.debug("adding object with title/element_id=%s/%s", info.title, info.element_id)
             model_name = mm.load_model_from_model_info(info, data['svg_name'])
 
+            pverts = info.path_vertices
+
             poly_shape = {
                 'shape_type': 'poly',
                 'elasticity': 0.6,
@@ -59,23 +61,13 @@ class TestGame(Widget):
                 'shape_info': {
                     'mass': 50,
                     'offset': (0, 0),
-                    'vertices': info.path_vertices + [info.path_vertices[0]]
+                    'vertices': pverts
                 }
 
             }
             
-            col_shape = {'shape_type': 'circle', 
-                         'elasticity': .5, 
-                         'collision_type': 1, 
-                         'shape_info': {
-                                        'inner_radius': 0, 
-                                        'outer_radius': 60, 
-                                        'mass': 50, 
-                                        'offset': (0, 0)
-                                       }, 
-                         'friction': 1.0}
-
             pos = (float(randint(100, 600)), float(randint(100, 400)))
+            #pos = (100, 100)
 
             physics = {
                     'main_shape': 'poly',

--- a/examples/16_svg_phys_objects/main.py
+++ b/examples/16_svg_phys_objects/main.py
@@ -1,0 +1,131 @@
+from kivy.app import App
+from kivy.logger import Logger
+from kivy.uix.widget import Widget
+from kivy.clock import Clock
+from kivy.core.window import Window
+from random import randint, choice
+from math import radians, pi, sin, cos
+import kivent_core
+import kivent_cymunk
+from kivent_core.gameworld import GameWorld
+from kivent_core.managers.resource_managers import texture_manager
+from kivent_core.systems.renderers import RotateRenderer
+from kivent_core.systems.position_systems import PositionSystem2D
+from kivent_core.systems.rotate_systems import RotateSystem2D
+from kivent_cymunk.interaction import CymunkTouchSystem
+from kivy.properties import StringProperty, NumericProperty
+from functools import partial
+from os.path import dirname, join, abspath
+
+texture_manager.load_atlas(join(dirname(dirname(abspath(__file__))), 'assets', 
+    'background_objects.atlas'))
+
+
+
+class TestGame(Widget):
+    def __init__(self, **kwargs):
+        super(TestGame, self).__init__(**kwargs)
+        self.gameworld.init_gameworld(
+            ['cymunk_physics', 'poly_renderer', 'rotate', 'position',  'cymunk_touch' ],
+            callback=self.init_game)
+
+    def init_game(self):
+        self.setup_states()
+        self.set_state()
+        self.draw_some_stuff()
+
+    def destroy_created_entity(self, ent_id, dt):
+        self.gameworld.remove_entity(ent_id)
+        self.app.count -= 1
+
+    def draw_some_stuff(self):
+
+        self.load_svg('objects.svg', self.gameworld)
+
+
+    def load_svg(self, fname, gameworld):
+        mm = gameworld.model_manager
+        data = mm.get_model_info_for_svg(fname)
+
+        for info in data['model_info']:
+            Logger.debug("adding object with title/element_id=%s/%s", info.title, info.element_id)
+            model_name = mm.load_model_from_model_info(info, data['svg_name'])
+
+            poly_shape = {
+                'shape_type': 'poly',
+                'elasticity': 0.6,
+                'collision_type': 1,
+                'friction': 1.0,
+                'shape_info': {
+                    'mass': 50,
+                    'offset': (0, 0),
+                    'vertices': info.path_vertices + [info.path_vertices[0]]
+                }
+
+            }
+            
+            col_shape = {'shape_type': 'circle', 
+                         'elasticity': .5, 
+                         'collision_type': 1, 
+                         'shape_info': {
+                                        'inner_radius': 0, 
+                                        'outer_radius': 60, 
+                                        'mass': 50, 
+                                        'offset': (0, 0)
+                                       }, 
+                         'friction': 1.0}
+
+            pos = (float(randint(100, 600)), float(randint(100, 400)))
+
+            physics = {
+                    'main_shape': 'poly',
+                    'velocity': (0, 0),
+                    'position': pos,
+                    'angle': 0,
+                    'angular_velocity': radians(0),
+                    'ang_vel_limit': radians(0),
+                    'mass': 50, 
+                    'col_shapes': [poly_shape]
+            }
+
+            create_dict = {
+                    'position': pos,
+                    'poly_renderer': {'model_key': model_name},
+                    'cymunk_physics': physics, 
+                    'rotate': radians(0),
+            }
+
+            ent = gameworld.init_entity(create_dict, ['position', 'rotate', 'poly_renderer', 'cymunk_physics'])
+            self.app.count += 1
+
+    def update(self, dt):
+        self.gameworld.update(dt)
+
+    def setup_states(self):
+        self.gameworld.add_state(state_name='main', 
+            systems_added=['poly_renderer'],
+            systems_removed=[], systems_paused=[],
+            systems_unpaused=['poly_renderer'],
+            screenmanager_screen='main')
+
+    def set_state(self):
+        self.gameworld.state = 'main'
+
+
+class DebugPanel(Widget):
+    fps = StringProperty(None)
+
+    def __init__(self, **kwargs):
+        super(DebugPanel, self).__init__(**kwargs)
+        Clock.schedule_once(self.update_fps)
+
+    def update_fps(self,dt):
+        self.fps = str(int(Clock.get_fps()))
+        Clock.schedule_once(self.update_fps, .05)
+
+class YourAppNameApp(App):
+    count = NumericProperty(0)
+
+
+if __name__ == '__main__':
+    YourAppNameApp().run()

--- a/examples/16_svg_phys_objects/objects.svg
+++ b/examples/16_svg_phys_objects/objects.svg
@@ -26,14 +26,14 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1324"
-     inkscape:window-height="753"
+     inkscape:window-width="1920"
+     inkscape:window-height="1065"
      id="namedview8"
      showgrid="false"
      inkscape:zoom="0.69532172"
      inkscape:cx="164.84846"
      inkscape:cy="285.79664"
-     inkscape:window-x="38"
+     inkscape:window-x="1362"
      inkscape:window-y="-3"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg5084" />
@@ -105,5 +105,8 @@
      style="fill:url(#linearGradient3764);stroke:#a1a1cc;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
      d="M 138.06559,357.75443 470.2859,37.039579 621.29514,244.13796 524.93686,399.46174 176.89653,438.29269 z"
      id="path3756"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0">
+    <desc
+       id="desc2992">dddesc</desc>
+  </path>
 </svg>

--- a/examples/16_svg_phys_objects/objects.svg
+++ b/examples/16_svg_phys_objects/objects.svg
@@ -25,14 +25,14 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1065"
+     inkscape:window-width="1324"
+     inkscape:window-height="753"
      id="namedview8"
      showgrid="false"
      inkscape:zoom="1.9666668"
-     inkscape:cx="225.4136"
-     inkscape:cy="267.3515"
-     inkscape:window-x="1362"
+     inkscape:cx="-17.637231"
+     inkscape:cy="365.48709"
+     inkscape:window-x="38"
      inkscape:window-y="-3"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg5084" />
@@ -67,24 +67,16 @@
     </rdf:RDF>
   </metadata>
   <rect
-     style="fill:#00ff00;fill-opacity:1"
-     id="rect2990"
-     width="48.305084"
-     height="55.423725"
-     x="130.67796"
-     y="68.135612" />
-  <rect
-     style="fill:#800080;fill-opacity:1"
-     id="rect2996"
-     width="15.762712"
-     height="180.50847"
-     x="240.50847"
-     y="117.96612" />
-  <rect
-     style="fill:#ff00ff;fill-opacity:1"
-     id="rect2998"
-     width="226.77965"
-     height="12.203389"
-     x="301.52542"
-     y="73.22036" />
+     style="fill:#008b00;fill-opacity:1;stroke:none"
+     id="reg"
+     width="50"
+     height="50"
+     x="0"
+     y="0"
+     inkscape:label="reg" />
+  <path
+     style="fill:#d40000;stroke:#ba7676;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 77.796605,68.135621 117.45762,12.711896 154.57626,88.474603 z"
+     id="path2986"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/examples/16_svg_phys_objects/objects.svg
+++ b/examples/16_svg_phys_objects/objects.svg
@@ -29,9 +29,9 @@
      inkscape:window-height="1065"
      id="namedview8"
      showgrid="false"
-     inkscape:zoom="1.3906434"
-     inkscape:cx="372.27955"
-     inkscape:cy="199.52396"
+     inkscape:zoom="1.9666668"
+     inkscape:cx="225.4136"
+     inkscape:cy="267.3515"
      inkscape:window-x="1362"
      inkscape:window-y="-3"
      inkscape:window-maximized="1"
@@ -66,24 +66,25 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1"
-     transform="matrix(3.6254514,0,0,1.655674,-505.92611,-158.625)">
-    <path
-       d="m 223.78868,231.64486 -26.90555,37.94819 0.0665,-37.74464 z"
-       id="bubu"
-       style="fill:#a60000;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-  </g>
-  <path
-     sodipodi:type="arc"
-     style="fill:#808000;fill-opacity:1"
-     id="path2984"
-     sodipodi:cx="464.53317"
-     sodipodi:cy="251.68842"
-     sodipodi:rx="44.583679"
-     sodipodi:ry="39.909584"
-     d="m 509.11685,251.68842 a 44.583679,39.909584 0 1 1 -89.16736,0 44.583679,39.909584 0 1 1 89.16736,0 z"
-     transform="matrix(-0.37096778,0,0,1,575.73723,0)" />
+  <rect
+     style="fill:#00ff00;fill-opacity:1"
+     id="rect2990"
+     width="48.305084"
+     height="55.423725"
+     x="130.67796"
+     y="68.135612" />
+  <rect
+     style="fill:#800080;fill-opacity:1"
+     id="rect2996"
+     width="15.762712"
+     height="180.50847"
+     x="240.50847"
+     y="117.96612" />
+  <rect
+     style="fill:#ff00ff;fill-opacity:1"
+     id="rect2998"
+     width="226.77965"
+     height="12.203389"
+     x="301.52542"
+     y="73.22036" />
 </svg>

--- a/examples/16_svg_phys_objects/objects.svg
+++ b/examples/16_svg_phys_objects/objects.svg
@@ -8,6 +8,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
@@ -29,15 +30,27 @@
      inkscape:window-height="753"
      id="namedview8"
      showgrid="false"
-     inkscape:zoom="1.9666668"
-     inkscape:cx="-17.637231"
-     inkscape:cy="365.48709"
+     inkscape:zoom="0.69532172"
+     inkscape:cx="164.84846"
+     inkscape:cy="285.79664"
      inkscape:window-x="38"
      inkscape:window-y="-3"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg5084" />
   <defs
      id="defs5086">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3758">
+      <stop
+         style="stop-color:#d40000;stop-opacity:1;"
+         offset="0"
+         id="stop3760" />
+      <stop
+         style="stop-color:#d40000;stop-opacity:0;"
+         offset="1"
+         id="stop3762" />
+    </linearGradient>
     <linearGradient
        id="linearGradient5218"
        osb:paint="solid">
@@ -53,6 +66,15 @@
     <inkscape:path-effect
        effect="spiro"
        id="path-effect5106" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3758"
+       id="linearGradient3764"
+       x1="137.56559"
+       y1="237.66613"
+       x2="621.79514"
+       y2="237.66613"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata5089">
@@ -78,5 +100,10 @@
      style="fill:#d40000;stroke:#ba7676;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      d="M 77.796605,68.135621 117.45762,12.711896 154.57626,88.474603 z"
      id="path2986"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:url(#linearGradient3764);stroke:#a1a1cc;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+     d="M 138.06559,357.75443 470.2859,37.039579 621.29514,244.13796 524.93686,399.46174 176.89653,438.29269 z"
+     id="path3756"
      inkscape:connector-curvature="0" />
 </svg>

--- a/examples/16_svg_phys_objects/objects.svg
+++ b/examples/16_svg_phys_objects/objects.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="640"
+   height="480"
+   id="svg5084"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="objects.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1065"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="1.3906434"
+     inkscape:cx="372.27955"
+     inkscape:cy="199.52396"
+     inkscape:window-x="1362"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5084" />
+  <defs
+     id="defs5086">
+    <linearGradient
+       id="linearGradient5218"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5220" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect2994"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect5106" />
+  </defs>
+  <metadata
+     id="metadata5089">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="matrix(3.6254514,0,0,1.655674,-505.92611,-158.625)">
+    <path
+       d="m 223.78868,231.64486 -26.90555,37.94819 0.0665,-37.74464 z"
+       id="bubu"
+       style="fill:#a60000;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <path
+     sodipodi:type="arc"
+     style="fill:#808000;fill-opacity:1"
+     id="path2984"
+     sodipodi:cx="464.53317"
+     sodipodi:cy="251.68842"
+     sodipodi:rx="44.583679"
+     sodipodi:ry="39.909584"
+     d="m 509.11685,251.68842 a 44.583679,39.909584 0 1 1 -89.16736,0 44.583679,39.909584 0 1 1 89.16736,0 z"
+     transform="matrix(-0.37096778,0,0,1,575.73723,0)" />
+</svg>

--- a/examples/16_svg_phys_objects/poscolorshader.glsl
+++ b/examples/16_svg_phys_objects/poscolorshader.glsl
@@ -1,0 +1,38 @@
+---VERTEX SHADER---
+#ifdef GL_ES
+    precision highp float;
+#endif
+
+/* Outputs to the fragment shader */
+varying vec4 frag_color;
+
+/* vertex attributes */
+attribute vec2     pos;
+attribute vec4     v_color;
+
+
+/* uniform variables */
+uniform mat4       modelview_mat;
+uniform mat4       projection_mat;
+uniform vec4       color;
+uniform float      opacity;
+
+void main (void) {
+  frag_color = v_color*color;
+  vec4 pos = vec4(pos.xy, 0.0, 1.0);
+  gl_Position = projection_mat * modelview_mat * pos;
+
+}
+
+
+---FRAGMENT SHADER---
+#ifdef GL_ES
+    precision highp float;
+#endif
+
+/* Outputs from the vertex shader */
+varying vec4 frag_color;
+
+void main (void){
+    gl_FragColor = frag_color;
+}

--- a/examples/16_svg_phys_objects/yourappname.kv
+++ b/examples/16_svg_phys_objects/yourappname.kv
@@ -1,0 +1,82 @@
+#:kivy 1.9.0
+#:import path os.path
+#:import dirname os.path.dirname
+#:import main __main__
+
+TestGame:
+
+<TestGame>:
+    gameworld: gameworld
+    app: app
+    GameWorld:
+        id: gameworld
+        gamescreenmanager: gamescreenmanager
+        size_of_gameworld: 100*1024
+        zones: {'general': 20000, 'touch': 100}
+        model_format_allocations: {'vertex_format_2f4ub': (150*1024, 150*1024),'vertex_format_4f': (150*1024, 150*1024) }
+        PositionSystem2D:
+            system_id: 'position'
+            gameworld: gameworld
+            zones: ['general', 'touch']
+
+        RotateSystem2D:
+            system_id: 'rotate'
+            gameworld: gameworld
+            zones: ['general']
+
+        PolyRenderer:
+            id: 'poly_renderer'
+            system_id: 'poly_renderer'
+            gameworld: gameworld
+            zones: ['general']
+            frame_count: 2
+            updateable: True
+            shader_source:  'poscolorshader.glsl'
+
+        CymunkPhysics:
+            gameworld: root.gameworld
+            zones: ['general']
+
+        CymunkTouchSystem:
+            gameworld: root.gameworld
+            zones: ['touch']
+            zone_to_use: 'touch'
+            physics_system: 'cymunk_physics'
+            touch_radius: 30
+
+    GameScreenManager:
+        id: gamescreenmanager
+        size: root.size
+        pos: root.pos
+        gameworld: gameworld
+
+<GameScreenManager>:
+    MainScreen:
+        id: main_screen
+
+<MainScreen@GameScreen>:
+    name: 'main'
+    FloatLayout:
+        Button:
+            text: 'Draw Some Stuff'
+            size_hint: (.2, .1)
+            pos_hint: {'x': .025, 'y': .025}
+            on_release: app.root.draw_some_stuff()
+        DebugPanel:
+            size_hint: (.2, .1)
+            pos_hint: {'x': .225, 'y': .025}
+        Label:
+            text: str(app.count)
+            size_hint: (.2, .1)
+            font_size: 24
+            pos_hint: {'x': .425, 'y': .025}
+
+<DebugPanel>:
+    Label:
+        pos: root.pos
+        size: root.size
+        font_size: root.size[1]*.5
+        halign: 'center'
+        valign: 'middle'
+        color: (1,1,1,1)
+        text: 'FPS: ' + root.fps if root.fps != None else 'FPS:'

--- a/modules/core/kivent_core/managers/resource_managers.pyx
+++ b/modules/core/kivent_core/managers/resource_managers.pyx
@@ -364,6 +364,7 @@ cdef class ModelManager(GameManager):
         cdef list svg_data = svg.get_model_data()
         self._svg_index[svg_name] = svg_info = {'model_info': svg_data,
                                                 'svg_name': svg_name,
+                                                'svg_object': svg,
                                                 'models': {}}
         return svg_info
 

--- a/modules/core/kivent_core/rendering/svg_loader.pxd
+++ b/modules/core/kivent_core/rendering/svg_loader.pxd
@@ -23,6 +23,7 @@ cdef dict parse_style(string)
 cdef parse_color(c, current_color=?)
 
 cdef class SVGModelInfo:
+    cdef public list path_vertices
     cdef list indices
     cdef dict vertices
     cdef int vertex_count

--- a/modules/core/kivent_core/rendering/svg_loader.pxd
+++ b/modules/core/kivent_core/rendering/svg_loader.pxd
@@ -55,6 +55,7 @@ cdef class SVG:
     cdef str element_id
     cdef str title
     cdef str description
+    cdef public str metadata_description
     cdef str label
     cdef list custom_fields
     cdef bint fill_was_none

--- a/modules/core/kivent_core/rendering/svg_loader.pyx
+++ b/modules/core/kivent_core/rendering/svg_loader.pyx
@@ -697,6 +697,13 @@ cdef class SVG:
         elif e.tag.endswith('radialGradient'):
             self.gradients[e.get('id')] = RadialGradient(e, self)
 
+        elif e.tag.endswith("metadata"):
+            x = e.find("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF"\
+                       "/{http://creativecommons.org/ns#}Work"\
+                       "/{http://purl.org/dc/elements/1.1/}description")
+
+            self.description = x.text if x else ""
+
         for c in e.getchildren():
             self.parse_element(c)
 

--- a/modules/core/kivent_core/rendering/svg_loader.pyx
+++ b/modules/core/kivent_core/rendering/svg_loader.pyx
@@ -575,7 +575,13 @@ cdef class SVG:
         oldtransform = self.transform
         self.element_id = e.get('id', None)
         self.title = e.get('title', None)
+        
         self.description = e.get('description', None)
+        #sodipodi description
+        desc = e.find("{http://www.w3.org/2000/svg}desc")
+        if desc is not None:
+            self.description = desc.text
+
         self.custom_data = custom_data = {}
         if self.custom_fields is not None:
             for key in self.custom_fields:
@@ -703,7 +709,6 @@ cdef class SVG:
                        "/{http://creativecommons.org/ns#}Work"\
                        "/{http://purl.org/dc/elements/1.1/}description")
 
-            Logger.debug("metadata x=%s", x)
             self.metadata_description = ""
             if x is not None:
                 self.metadata_description = x.text 

--- a/modules/core/kivent_core/rendering/svg_loader.pyx
+++ b/modules/core/kivent_core/rendering/svg_loader.pyx
@@ -454,6 +454,7 @@ cdef class SVG:
         self.element_id = None
         self.title = None
         self.description = None
+        self.metadata_description = None
         self.fill_was_none = False
         self.anchor_y = anchor_y
         self.line_texture = Texture.create(
@@ -702,7 +703,10 @@ cdef class SVG:
                        "/{http://creativecommons.org/ns#}Work"\
                        "/{http://purl.org/dc/elements/1.1/}description")
 
-            self.description = x.text if x else ""
+            Logger.debug("metadata x=%s", x)
+            self.metadata_description = ""
+            if x is not None:
+                self.metadata_description = x.text 
 
         for c in e.getchildren():
             self.parse_element(c)

--- a/modules/core/kivent_core/rendering/svg_loader.pyx
+++ b/modules/core/kivent_core/rendering/svg_loader.pyx
@@ -1318,6 +1318,7 @@ cdef class SVG:
             vert_offset = 0
             
             path_vertices = zip(path[::2], path[1::2])
+            path_vertices = [ (x, self.height - y) for x,y in path_vertices ]
             Logger.debug("path_vertices is %r", path_vertices)
 
             for element in subelements:

--- a/modules/core/kivent_core/rendering/svg_loader.pyx
+++ b/modules/core/kivent_core/rendering/svg_loader.pyx
@@ -317,7 +317,8 @@ cdef class SVGModelInfo:
 
     def __init__(self, list indices, dict vertices,
         str title=None, str element_id=None,
-        str description=None, dict custom_data=None):
+        str description=None, dict custom_data=None, 
+        list path_vertices=None):
         if custom_data is None:
             custom_data = {}
         self.indices = indices
@@ -328,10 +329,11 @@ cdef class SVGModelInfo:
         self.title = title
         self.element_id = element_id
         self.custom_data = custom_data
+        self.path_vertices = path_vertices
 
     def combine_model_info(self, SVGModelInfo new_info):
         '''
-        Returns a new SVGModelInfo object that contains the combined vertex
+        ..Returns a new SVGModelInfo object that contains the combined vertex
         and index data for this object and the SVGModelInfo object provided 
         by the new_info argument. 
 
@@ -368,6 +370,7 @@ cdef class SVGModelInfo:
                                 description=self.description,
                                 element_id=self.element_id,
                                 title=self.title,
+                                path_vertices=self.path_vertices
                                 )
 
 
@@ -1313,6 +1316,10 @@ cdef class SVG:
             final_indices = []
             final_ind_ext = final_indices.extend
             vert_offset = 0
+            
+            path_vertices = zip(path[::2], path[1::2])
+            Logger.debug("path_vertices is %r", path_vertices)
+
             for element in subelements:
                 vertices = element.vertices
                 final_ind_ext([x + vert_offset for x in element.indices])
@@ -1325,7 +1332,8 @@ cdef class SVG:
                                         description=description,
                                         element_id=element_id,
                                         title=title,
-                                        custom_data=custom_data
+                                        custom_data=custom_data,
+                                        path_vertices=path_vertices
                                         ))
 
         return elements

--- a/modules/core/kivent_core/systems/staticmemgamesystem.pyx
+++ b/modules/core/kivent_core/systems/staticmemgamesystem.pyx
@@ -18,6 +18,7 @@ from cpython cimport bool
 from kivent_core.memory_handlers.utils import memrange
 
 
+
 cdef class MemComponent:
     '''The base for a cdef extension that will work with the MemoryBlock
     memory management system. The data do not live inside the MemComponent,


### PR DESCRIPTION
Hi, 

I added functionality to SVNModelInfo which stores original path of object, before triangulisation. It's neccesary to use polyline cymunk shape. 

Also, I made example to load physics objects from .svg file. 

However, I ecountered problem: initially I wanted object to be loaded in normalized coordinates. Eg - rectangle is in 0, 480 in svg. And it's loaded as entity at position 0,0, with polyline at 0, 480. I wanted it to be loaded as entity located at 0,480 with polyline around 0,0. 

I tried to "normalize" coordinates of vertexes (uncomment appropriate line in load_svg) but then it looks ok, but doesn't work ok - collision between objects are a bit strange (object hover above another before collision or they collide when they are dozen pixels apart). When I don't normalize - collision are pixel-perfect. If you have any idea how to make all objects to be loaded with polylines around it's center - let me know and I'll amend it. Otherwise - this example is still usable. 

