### PR TITLE
Add wheels for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,236 @@
+version: 1.0.{build}
+os: Visual Studio 2015
+environment:
+  WHEEL_DIR: C:\kivent_wheels
+  KIVENT_BUILD_DIR: C:\kivent_build
+  AIRPLANE_CHARGE:
+    secure: HgQr7XMKpB6lWn33SKv0GyYZbh1RfpgvaIKEE0B54R5XHJujQg5dhOEB3Vc2CfAqCprX+CGxXAjQwFnuv6pJeA3++9Z8/1SfFuEqCF59J7PqsDs2thA8lNHLRsThvRVJrBt2jcb1wrG3Nf3sz3vi7e+rBzYjprkcYiTP0XJ5FdQekyFTTjuXYaRBGWrwGX81dEVVUkGFuEZFYWJq2Yf/PkFGOX+IN0CjgpFB0pGfZSJcIG7mvscurfG/KvckLhNUINprUKt0pJ8iCN0iufsbmrOnuG+WC8AHktvlSxzHSfCm8zmhSZTkDNkJfpYHapFagQQThmiYq8PqsVIC0XOz+j4KLljc6bxyhE0oPtOPg4DohBdqLI28V1XB/Kqh7CCZR50wAw567voWVOtKsyets5oeywZH1q/gtK6stC5t7v+a2s0w1I2IEW6p2aPy7plreZj15QCgIR8h6JgIuMuwqiaVCUuhej/GauCZG/9jIBJpTf1NkBa9k4vIxHPq5R5/ltYX8za49vz5ImdLe1qlTFwy9fegMpb+D5m3y3ilm+t5xkDmqXQau1oVWIVd8jf0DawWqkNsKLp6hbYr51gclS+Gc7NVKwvFtcmoAfbvNCGBDH4vF6cR2wNhy6RDjjqDgIStnpUs3fKS9bKOyrv9+394esQqEuAXgLtC2vUMk+z3Hf8V18AFYKZfZmWxiGGrjI6YQCBOBOdh5VO5cASqtoTU22OvAPhXT7gX2JG96Rc9yf/K8DEvzuWo3lArDAclh2zLm++1SOh54dDiAiMZvLkNXu5tAsg60c+rJCx4FQ9ra0/GcFY1LKJntdKvpQyBkp4wKAvq3YyV7Rnx8u6PULXXG2rS6i7m+asLrY+FSCO5oRmLrMv5pEv0cF/BOAh0RGR6medX8ASmM40sHqz+WC9WJfaSUZplSzQwHxXCr/AzK40mOTtKgkg8e8tqwNzjI8mdjx0kwcu8zuOeUK6U6l83voGKbli1gzinkLvzhjvF1TXZwpT1y/HvAs5dGwXVfdigeOqcfmIOxXStPmaZ4CZRKVK3CgweYzpETyT6Pm5H3jANcAuyYuphJr7YrfHfWKAg6N3Q0r3AfzliOuIBm3DVfm2RuI8USGJxRsjaDX8LB8sdhrCPLUYBh1RNhYol5bVEM1IX+BcpXzIyqv00eSMTvN3G7KdsM+/8LGlnEM+apIgnBlVfcWOQI8rzBkXuJvExSwDhKzncGWbi12UapEVsE/QnVpDiwbiPdZtQQzQ=
+  GDRIVE_CLIENT_ID:
+    secure: iGAZpJPOTLhRmK7X60xzRZm1S0PbmoMwoVJdd8WiKBH34Tqsd6UEFhPjLLok7J0+xWStS8E3fwEQh4Wzn1BCXhry5Qv8FLD41oskVpiSwdc=
+  GDRIVE_CLIENT_SECRET:
+    secure: 7J8TZnhr3MsF5rveMVVkbrr9tzTwGG6rHWZMorW0WN4=
+  GDRIVE_KIVENT_UPLOAD_ID: 0B2_WZb3FJkzhMnNLTlZtUjJENHM
+  KIVENT_USE_SETUPTOOLS: 1
+  matrix:
+  - PYVER: 27
+    BITTNESS: 86
+    COMPILER: mingw
+  - PYVER: 27
+    BITTNESS: 64
+    COMPILER: mingw
+  - PYVER: 34
+    BITTNESS: 86
+    COMPILER: mingw
+  - PYVER: 34
+    BITTNESS: 64
+    COMPILER: mingw
+install:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-desktop.ps1'))
+build_script:
+- ps: >-
+    function Check-Error
+
+    {
+      param([int]$SuccessVal = 0)
+      if ($SuccessVal -ne $LastExitCode) {
+        throw "Failed with exit code $LastExitCode"
+      }
+    }
+
+    echo "Bitness=$env:BITTNESS, scheduled=$env:APPVEYOR_SCHEDULED_BUILD, forced=$env:APPVEYOR_FORCED_BUILD, rebuild=$env:APPVEYOR_RE_BUILD, tagged=$env:APPVEYOR_REPO_TAG"
+
+    cd $env:APPVEYOR_BUILD_FOLDER
+
+    git clone -q --branch=master https://github.com/kivy/kivy-sdk-packager.git C:\projects\kivy-sdk-packager
+
+    Check-Error
+
+    $PYTHONPATH = "$env:APPVEYOR_BUILD_FOLDER;$PYTHONPATH"
+
+    echo "Build folder: $env:APPVEYOR_BUILD_FOLDER. Wheel folder: $env:WHEEL_DIR."
+
+    mkdir "$env:KIVENT_BUILD_DIR"
+
+    Check-Error
+
+    mkdir "$env:WHEEL_DIR"
+
+    Check-Error
+
+    C:\Python27\Scripts\pip.exe install pydrive
+
+    Check-Error
+
+
+    # Get ARCH for wheels
+
+    if ($env:BITTNESS -eq "64") {
+      $PYTHON_ROOT = "C:\Python$env:PYVER-x64"
+      $WHEEL_BITNESS = "win_amd64"
+    } else {
+      $PYTHON_ROOT = "C:\Python$env:PYVER"
+      $WHEEL_BITNESS = "win32"
+    }
+
+    $WHEEL_DATE = python -c "from datetime import datetime;print(datetime.utcnow().strftime('%Y%m%d'))"
+
+    $GIT_TAG = git rev-parse --short HEAD
+
+    Check-Error
+
+    $env:PATH = "$PYTHON_ROOT;$PYTHON_ROOT\Scripts;$env:PATH;C:\Program Files\7-Zip"
+
+    $env:PATH = $PYTHON_ROOT+"\share\glew\bin;"+$PYTHON_ROOT+"\share\sdl2\bin;"+$env:PATH
+
+    Check-Error
+
+
+    # Set up shortcuts
+
+    $WD = ${env:WHEEL_DIR}
+
+    $CP = "cp${env:PYVER}-cp${env:PYVER}m-${WHEEL_BITNESS}.whl"
+
+    $R = "import re;import os;f=open(os.path.join('"
+
+    $X = "','setup.py'));print(re.findall('version=\'(.*?)\',?',f.read())[-1]);f.close()"
+
+    Check-Error
+
+    $env:DO_TEST = "False" # switch to True when tests are available
+
+    if ($env:APPVEYOR_SCHEDULED_BUILD -eq "True"){
+      $env:DO_TEST = "False"
+    }
+
+
+    $DO_WHEEL = "True"
+
+    # Set new wheel name, keep default if release (tag)
+    # release: KivEnt-X.Y.Z-cpAB-cpABm-ARCH.whl
+    # nightly: KivEnt-X.Y.Z.dev0-cpAB-cpABm-ARCH.whl
+    # archive: KivEnt-X.Y.Z.dev0.YYYYMMDD.githash-cpAB-cpABm-ARCH.whl
+
+    if ($env:APPVEYOR_REPO_TAG -eq "true"){
+      $WHEEL_NAME = "dev0-"
+    } elseif ($env:APPVEYOR_SCHEDULED_BUILD -eq "True" -or $env:APPVEYOR_FORCED_BUILD -eq "True" -or $env:APPVEYOR_RE_BUILD -eq "True"){
+      $WHEEL_NAME = "dev0.$WHEEL_DATE`.$GIT_TAG-"
+    } else {
+      $DO_WHEEL = "False"
+    }
+
+    if ($env:APPVEYOR_REPO_BRANCH -ne "master") {
+      $DO_WHEEL = "False"
+    }
+
+    echo "test=$env:DO_TEST, make_wheel=$DO_WHEEL"
+
+    python -m pip install pip wheel setuptools --upgrade
+
+    Check-Error
+
+    if ($env:COMPILER -ne "msvc") {
+      python -c "with open(r'$PYTHON_ROOT\Lib\distutils\distutils.cfg', 'wb') as fh: fh.write(b'[build]\ncompiler = mingw32\n')"
+      Check-Error
+      pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy
+      Check-Error
+    }
+
+    pip install mock cython pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.sdl2_dev kivy.deps.sdl2
+
+    Check-Error
+
+    pip install kivy.deps.angle
+
+    $kivy_url = "https://kivy.org/downloads/appveyor/kivy"
+
+    # get kivy version at runtime later, magically
+
+    pip install "$kivy_url/Kivy-1.9.2.dev0-${CP}"
+
+    Check-Error
+
+    pip install https://github.com/tito/cymunk/zipball/master
+
+    Check-Error
+
+
+
+    $DO_WHEEL = "True"  # Remove later
+
+    # cd to kivent/modules, list modules
+
+    if ($DO_WHEEL -eq "True") {
+      cd modules
+
+      $modules = Get-ChildItem "$pwd" -Name
+
+      echo "Found KivEnt modules: [$modules]"
+
+      Check-Error
+
+
+      # Get versions from modules' setup.py
+
+      foreach ($mod in $modules) {
+        if ($mod -eq "core") {
+          $CORE_V = python -c "${R}${mod}${X}"
+        } elseif ($mod -eq "cymunk") {
+          $CYM_V = python -c "${R}${mod}${X}"
+        } elseif ($mod -eq "maps") {
+          $MAPS_V = python -c "${R}${mod}${X}"
+        } elseif ($mod -eq "particles") {
+          $PART_V = python -c "${R}${mod}${X}"
+        } elseif ($mod -eq "projectiles") {
+          $PROJ_V = python -c "${R}${mod}${X}"
+        }
+      }
+
+      Check-Error
+
+
+      # Make wheels & pip install after
+
+      foreach ($mod in $modules) {
+        cd "$mod"
+        if (test-path "setup.py") {python setup.py bdist_wheel -d "${WD}"}
+        Check-Error
+        cd ..
+        if ($mod -eq "core") {
+          pip install "${WD}\KivEnt_Core-${CORE_V}-${CP}"
+        } elseif ($mod -eq "cymunk") {
+          pip install "${WD}\KivEnt_Cymunk-${CYM_V}-${CP}"
+        } elseif ($mod -eq "maps") {
+          pip install "${WD}\KivEnt_maps-${MAPS_V}-${CP}"
+        } elseif ($mod -eq "particles") {
+          pip install "${WD}\KivEnt_particles-${PART_V}-${CP}"
+        } elseif ($mod -eq "projectiles") {
+          pip install "${WD}\KivEnt_projectiles-${PROJ_V}-${CP}"
+        }
+        dir "${WD}"
+      }
+
+
+      # Default file bdist_wheel creates:
+      # KivEnt-X.Y.Z[.dev0]-cpAB-cpABm-ARCH.whl
+
+      $files = Get-ChildItem "$env:WHEEL_DIR" *.whl -Name
+      foreach ($WHEEL_DEFAULT in $files){
+        echo "Wheel file: $env:WHEEL_DIR\$WHEEL_DEFAULT"
+        $WHEEL_NIGHTLY = $WHEEL_DEFAULT.Replace("dev0-", $WHEEL_NAME)
+        echo "Nightly file: $env:WHEEL_DIR\$WHEEL_NIGHTLY"
+        Check-Error
+
+        echo "Copying from default $WHEEL_DEFAULT to nightly $WHEEL_NIGHTLY"
+        Copy-Item "$env:WHEEL_DIR\$WHEEL_DEFAULT" "$env:WHEEL_DIR\$WHEEL_NIGHTLY"
+        Check-Error
+      }
+
+      dir "${WD}"
+
+      C:\Python27\python.exe C:\projects\kivy-sdk-packager\win\gdrive.py upload "$env:GDRIVE_KIVY_UPLOAD_ID" "$env:WHEEL_DIR\*"
+      Check-Error
+
+      C:\Python27\python.exe C:\projects\kivy-sdk-packager\win\gdrive.py delete_older "$env:GDRIVE_KIVY_UPLOAD_ID" "15"
+      Check-Error
+    }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -150,10 +150,34 @@ build_script:
 
     Check-Error
 
-    pip install https://github.com/tito/cymunk/zipball/master
+
+    # Create cymunk wheel (kivent_cymunk dependency)
+
+    git clone -q --branch=master https://github.com/tito/cymunk.git C:\projects\tito_cymunk
 
     Check-Error
 
+    $cys = "C:\projects\tito_cymunk\setup.py"
+
+    $dist = "from distutils.core import setup\nfrom distutils.extension import Extension"
+
+    $sett = "from setuptools import setup, Extension"
+
+    python -c "f=open(r'${cys}');r=f.read();f.close();f=open(r'${cys}','w');f.write(r.replace('${dist}','${sett}'));f.close()"
+
+    Check-Error
+
+    cd C:\projects\tito_cymunk
+
+    python setup.py bdist_wheel -d "${WD}"
+
+    Check-Error
+
+    pip install "${WD}\cymunk-0.0.0-${CP}"
+
+    Check-Error
+
+    cd $env:APPVEYOR_BUILD_FOLDER
 
 
     $DO_WHEEL = "True"  # Remove later

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -228,9 +228,9 @@ build_script:
 
       dir "${WD}"
 
-      C:\Python27\python.exe C:\projects\kivy-sdk-packager\win\gdrive.py upload "$env:GDRIVE_KIVY_UPLOAD_ID" "$env:WHEEL_DIR\*"
+      C:\Python27\python.exe C:\projects\kivy-sdk-packager\win\gdrive.py upload "$env:GDRIVE_KIVENT_UPLOAD_ID" "$env:WHEEL_DIR\*"
       Check-Error
 
-      C:\Python27\python.exe C:\projects\kivy-sdk-packager\win\gdrive.py delete_older "$env:GDRIVE_KIVY_UPLOAD_ID" "15"
+      C:\Python27\python.exe C:\projects\kivy-sdk-packager\win\gdrive.py delete_older "$env:GDRIVE_KIVENT_UPLOAD_ID" "15"
       Check-Error
     }

--- a/modules/core/setup.py
+++ b/modules/core/setup.py
@@ -1,10 +1,16 @@
 from os import environ, remove
 from platform import uname
 from os.path import join, isfile, exists
-from distutils.core import setup
-from distutils.extension import Extension
 import kivy
 from subprocess import check_output
+
+if environ.get('KIVENT_USE_SETUPTOOLS'):
+    from setuptools import setup, Extension
+    print('Using setuptools')
+else:
+    from distutils.core import setup
+    from distutils.extension import Extension
+    print('Using distutils')
 
 try:
     from Cython.Build import cythonize
@@ -183,7 +189,7 @@ else:
 
 setup(
     name='KivEnt Core',
-    version='2.2.0dev',
+    version='2.2.0.dev0',
     description='''A game engine for the Kivy Framework.
         https://github.com/Kovak/KivEnt for more info.''',
     author='Jacob Kovac',

--- a/modules/cymunk/setup.py
+++ b/modules/cymunk/setup.py
@@ -1,10 +1,16 @@
 import pkgutil
-from distutils.core import setup
-from distutils.extension import Extension
 from os import environ, remove
 from platform import uname
 from os.path import join, isfile, exists, dirname
 from subprocess import check_output
+
+if environ.get('KIVENT_USE_SETUPTOOLS'):
+    from setuptools import setup, Extension
+    print('Using setuptools')
+else:
+    from distutils.core import setup
+    from distutils.extension import Extension
+    print('Using distutils')
 
 try:
     from Cython.Build import cythonize
@@ -100,6 +106,10 @@ check_for_removal = [
 
 loader = pkgutil.get_loader("cymunk")
 cymunk_dirname = loader.path if hasattr(loader, 'path') else loader.filename
+
+# pkgutil gives different results for py3
+if '__init__.py' in cymunk_dirname:
+    cymunk_dirname = dirname(cymunk_dirname)
 
 
 def build_ext(ext_name, files, include_dirs=[cymunk_dirname]):

--- a/modules/maps/setup.py
+++ b/modules/maps/setup.py
@@ -1,8 +1,15 @@
 from os import environ, remove
 from os.path import dirname, join, isfile
-from distutils.core import setup
-from distutils.extension import Extension
 import kivy
+
+if environ.get('KIVENT_USE_SETUPTOOLS'):
+    from setuptools import setup, Extension
+    print('Using setuptools')
+else:
+    from distutils.core import setup
+    from distutils.extension import Extension
+    print('Using distutils')
+
 try:
     from Cython.Build import cythonize
     from Cython.Distutils import build_ext

--- a/modules/particles/setup.py
+++ b/modules/particles/setup.py
@@ -1,11 +1,17 @@
-from distutils.core import setup
-from distutils.extension import Extension
 from os import environ, remove
 from platform import uname
 from os.path import join, isfile, exists
 from subprocess import check_output
 
 import kivy
+
+if environ.get('KIVENT_USE_SETUPTOOLS'):
+    from setuptools import setup, Extension
+    print('Using setuptools')
+else:
+    from distutils.core import setup
+    from distutils.extension import Extension
+    print('Using distutils')
 
 try:
     from Cython.Build import cythonize

--- a/modules/projectiles/setup.py
+++ b/modules/projectiles/setup.py
@@ -1,9 +1,15 @@
-from distutils.core import setup
-from distutils.extension import Extension
 from os import environ, remove
 from platform import uname
 from os.path import join, isfile, exists
 from subprocess import check_output
+
+if environ.get('KIVENT_USE_SETUPTOOLS'):
+    from setuptools import setup, Extension
+    print('Using setuptools')
+else:
+    from distutils.core import setup
+    from distutils.extension import Extension
+    print('Using distutils')
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
Currently only Python 27 and 34 are supported because of the `alloca.h` error in Chipmunk2D. Until fixed, VS won't install Cymunk, ... and so on.

The wheels should be uploaded to a separate folder like it is now with Kivy.

The projectiles setup.py is an automatic conversion to LF as git reported something bad about it.