### PR TITLE
RotationPolyRenderer

### DIFF
--- a/examples/assets/glsl/polyposcolorrotateshader.glsl
+++ b/examples/assets/glsl/polyposcolorrotateshader.glsl
@@ -1,0 +1,50 @@
+---VERTEX SHADER---
+#ifdef GL_ES
+    precision highp float;
+#endif
+
+/* Outputs to the fragment shader */
+varying vec4 frag_color;
+
+/* vertex attributes */
+attribute vec2     pos;
+attribute float    rot;
+attribute vec2     center;
+attribute vec4     v_color;
+
+
+/* uniform variables */
+uniform mat4       modelview_mat;
+uniform mat4       projection_mat;
+uniform vec4       color;
+uniform float      opacity;
+
+void main (void) {
+  frag_color = v_color * color * vec4(1.0, 1.0, 1.0, opacity);
+  float a_sin = sin(rot);
+  float a_cos = cos(rot);
+  mat4 rot_mat = mat4(a_cos, -a_sin, 0.0, 0.0,
+                a_sin, a_cos, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0,
+                0.0, 0.0, 0.0, 1.0 );
+  mat4 trans_mat = mat4(1.0, 0.0, 0.0, center.x,
+              0.0, 1.0, 0.0, center.y,
+              0.0, 0.0, 1.0, 0.0,
+              0.0, 0.0, 0.0, 1.0);
+  vec4 new_pos = vec4(pos.xy, 0.0, 1.0);
+  vec4 trans_pos = new_pos * rot_mat * trans_mat;
+  gl_Position = projection_mat * modelview_mat * trans_pos;
+}
+
+
+---FRAGMENT SHADER---
+#ifdef GL_ES
+    precision highp float;
+#endif
+
+/* Outputs from the vertex shader */
+varying vec4 frag_color;
+
+void main (void){
+    gl_FragColor = frag_color;
+}

--- a/modules/core/kivent_core/rendering/vertex_formats.pxd
+++ b/modules/core/kivent_core/rendering/vertex_formats.pxd
@@ -18,13 +18,20 @@ ctypedef struct VertexFormat4F4UB:
 ctypedef struct VertexFormat2F4UB:
     GLfloat[2] pos
     GLubyte[4] v_color
-
+        
+ctypedef struct VertexFormat5F4UB:
+    GLfloat[2] pos
+    GLfloat rot
+    GLfloat[2] center
+    GLubyte[4] v_color
+    
 ctypedef struct VertexFormat7F4UB:
     GLfloat[2] pos
     GLfloat[2] uvs
     GLfloat rot
     GLfloat[2] center
     GLubyte[4] v_color
+
 
 cdef class FormatConfig:
     cdef unsigned int _size

--- a/modules/core/kivent_core/rendering/vertex_formats.pyx
+++ b/modules/core/kivent_core/rendering/vertex_formats.pyx
@@ -200,6 +200,7 @@ format_registrar.register_vertex_format(
     'vertex_format_2f4ub', vertex_format_2f4ub, sizeof(VertexFormat2F4UB)
     )
 
+
 cdef VertexFormat7F4UB* tmp5 = <VertexFormat7F4UB*>NULL
 pos_offset = <Py_ssize_t> (<Py_intptr_t>(tmp5.pos) - <Py_intptr_t>(tmp5))
 uvs_offset = <Py_ssize_t> (<Py_intptr_t>(tmp5.uvs) - <Py_intptr_t>(tmp5))
@@ -217,4 +218,22 @@ vertex_format_7f4ub = [
 
 format_registrar.register_vertex_format(
     'vertex_format_7f4ub', vertex_format_7f4ub, sizeof(VertexFormat7F4UB)
+    )
+
+
+cdef VertexFormat5F4UB* tmp6 = <VertexFormat5F4UB*>NULL
+pos_offset = <Py_ssize_t> (<Py_intptr_t>(tmp6.pos) - <Py_intptr_t>(tmp6))
+rot_offset = <Py_ssize_t> (<Py_intptr_t>(&tmp6.rot) - <Py_intptr_t>(tmp6))
+center_offset = <Py_ssize_t> (<Py_intptr_t>(tmp6.center) - <Py_intptr_t>(tmp6))
+color_offset = <Py_ssize_t> (<Py_intptr_t>(tmp6.v_color) - <Py_intptr_t>(tmp6))
+
+vertex_format_5f4ub = [
+    (b'pos', 2, b'float', pos_offset, False), 
+    (b'rot', 1, b'float', rot_offset, False),
+    (b'center', 2, b'float', center_offset, False),
+    (b'v_color', 4, b'ubyte', color_offset, True),
+    ]
+
+format_registrar.register_vertex_format(
+    'vertex_format_5f4ub', vertex_format_5f4ub, sizeof(VertexFormat5F4UB)
     )

--- a/modules/core/kivent_core/systems/renderers.pxd
+++ b/modules/core/kivent_core/systems/renderers.pxd
@@ -49,6 +49,12 @@ cdef class ColorRenderer(Renderer):
 cdef class PolyRenderer(Renderer):
     pass
 
+cdef class RotatePolyRenderer(Renderer):
+    pass
+
+cdef class RotateColorScalePolyRenderer(RotatePolyRenderer):
+    pass
+
 cdef class ColorPolyRenderer(Renderer):
     pass
 


### PR DESCRIPTION
This PR contains a `RotatePolyRenderer` and a `RotateColorScalePolyRenderer`.  

Like the other PolyRenderer they expect a `vertex_format_2f4ub` model format.  
Otherwise they behave almost exactly like the corresponding non poly renderer.  
Both need the `polyposcolorrotateshader.glsl` which i moved into the example/assets/glsl folder.  

I am not 100% sure everything works like expected (Increasing `r` leads to counter clockwise rotation) but the results are matching with the corresponding texture renderer.