### PR TITLE
Fixed a bug regarding the render property in ParticleRenderer

### DIFF
--- a/modules/particles/kivent_particles/particle_renderers.pyx
+++ b/modules/particles/kivent_particles/particle_renderers.pyx
@@ -127,7 +127,7 @@ cdef class ParticleRenderer(Renderer):
                                 vertex.rotate = rot_comp.r
                                 for i in range(4):
                                     vertex.v_color[i] = color_comp.color[i]
-                        index_offset += model._index_count
+                            index_offset += model._index_count
                     batch.set_index_count_for_frame(index_offset)
                 mesh_instruction = batch.mesh_instruction
                 mesh_instruction.flag_update()


### PR DESCRIPTION
The ParticleRenderer didn't handle the 'RenderComponent.render' property properly when set to False.