### PR TITLE
Speed up Particlesystem update

### DIFF
--- a/modules/particles/kivent_particles/particle.pyx
+++ b/modules/particles/kivent_particles/particle.pyx
@@ -475,27 +475,30 @@ cdef class ParticleSystem(StaticMemGameSystem):
                 if particle_comp.emit_radius < emitter._min_radius:
                     particle_comp.current_time = particle_comp.total_time
             else:
-                start_x = particle_comp.start_pos[0]
-                start_y = particle_comp.start_pos[1]
-                current_x = pos_comp.x
-                current_y = pos_comp.y
-                distance_x = current_x - start_x
-                distance_y = current_y - start_y
-                distance_scalar = calc_distance(start_x, start_y, 
-                    current_x, current_y)
-                if distance_scalar < 0.01:
-                    distance_scalar = 0.01
-                radial_x = distance_x / distance_scalar
-                radial_y = distance_y / distance_scalar
-                tangential_x = radial_x
-                tangential_y = radial_y
-                rad_accel = particle_comp.radial_acceleration
-                radial_x *= rad_accel
-                radial_y *= rad_accel
-                new_y = tangential_x
-                tan_accel = particle_comp.tangential_acceleration
-                tangential_x = -tangential_y * tan_accel
-                tangential_y = new_y * tan_accel
+                if particle_comp.radial_acceleration or particle_comp.tangential_acceleration:
+                    start_x = particle_comp.start_pos[0]
+                    start_y = particle_comp.start_pos[1]
+                    current_x = pos_comp.x
+                    current_y = pos_comp.y
+                    distance_x = current_x - start_x
+                    distance_y = current_y - start_y
+                    distance_scalar = calc_distance(start_x, start_y, 
+                        current_x, current_y)
+                    if distance_scalar < 0.01:
+                        distance_scalar = 0.01
+                    radial_x = distance_x / distance_scalar
+                    radial_y = distance_y / distance_scalar
+                    tangential_x = radial_x
+                    tangential_y = radial_y
+                    rad_accel = particle_comp.radial_acceleration
+                    radial_x *= rad_accel
+                    radial_y *= rad_accel
+                    new_y = tangential_x
+                    tan_accel = particle_comp.tangential_acceleration
+                    tangential_x = -tangential_y * tan_accel
+                    tangential_y = new_y * tan_accel
+                else:
+                    radial_x = radial_y = tangential_x = tangential_y = 0
                 particle_comp.velocity[0] += passed_time * (
                     emitter._gravity[0] + radial_x + tangential_x)
                 particle_comp.velocity[1] += passed_time * (

--- a/modules/particles/kivent_particles/particle_math.pxi
+++ b/modules/particles/kivent_particles/particle_math.pxi
@@ -62,6 +62,6 @@ cdef inline void color_copy(float* from_color, unsigned char* destination):
 
 cdef inline float calc_distance(float point_1_x, float point_1_y, 
     float point_2_x, float point_2_y):
-    cdef float x_dist2 = pow(point_2_x - point_1_x, 2)
-    cdef float y_dist2 = pow(point_2_y - point_1_y, 2)
-    return sqrt(x_dist2 + y_dist2)
+    cdef double x_dist2 = pow(<double>(point_2_x - point_1_x), 2)
+    cdef double y_dist2 = pow(<double>(point_2_y - point_1_y), 2)
+    return <float>sqrt(x_dist2 + y_dist2)

--- a/modules/particles/kivent_particles/particle_math.pxi
+++ b/modules/particles/kivent_particles/particle_math.pxi
@@ -1,6 +1,6 @@
 from libc.math cimport fmax, fmin, sqrt
 from libc.stdlib cimport rand, RAND_MAX
-from libc.math cimport sin, cos
+from libc.math cimport sin, cos, pow
 
 DEF PI = 3.14159265358979323846
 

--- a/modules/particles/kivent_particles/particle_math.pxi
+++ b/modules/particles/kivent_particles/particle_math.pxi
@@ -62,6 +62,8 @@ cdef inline void color_copy(float* from_color, unsigned char* destination):
 
 cdef inline float calc_distance(float point_1_x, float point_1_y, 
     float point_2_x, float point_2_y):
-    cdef double x_dist2 = pow(<double>(point_2_x - point_1_x), 2)
-    cdef double y_dist2 = pow(<double>(point_2_y - point_1_y), 2)
+    cdef double x_dist2 = point_2_x - point_1_x
+    cdef double y_dist2 = point_2_y - point_1_y
+    x_dist2 *= x_dist2
+    y_dist2 *= y_dist2    
     return <float>sqrt(x_dist2 + y_dist2)


### PR DESCRIPTION
While profiling the Particlesystem i saw the particle.math.calc_distance eating up a lot of the time.

The function is using the python implementation of `pow` at the moment which is slow in comparison.
Switching to c math.pow function is noticeable faster but won't handle number overflows as nicely i assume.

Of course there is still the `sqrt` call which is also not cheap (and there might be a way to get rid of the `sqrt` call altogether). So i moved all the tangential and radial computation in the update loop behind a condition to check if we need to calculate them.

This changes are more noticeable in the performance when using a buffered ParticleSystem as the creating and removing of elements takes a lot of time in comparison.





