### PR TITLE
Ensure the entities component_id for removed components is set to -1

### DIFF
--- a/modules/core/kivent_core/entity.pyx
+++ b/modules/core/kivent_core/entity.pyx
@@ -53,9 +53,9 @@ cdef class Entity(MemComponent):
         system = system_manager[name]
         cdef unsigned int* pointer = <unsigned int*>self.pointer
         cdef unsigned int component_index = pointer[system_index+1]
-        if component_index == -1:
+        if component_index == <unsigned int>-1:
             raise NoComponentActiveError(
-                'Entity {ent_id} have no component'
+                'Entity {ent_id} has no component '
                 'active for {system_name}'.format(ent_id=str(self._id),
                     system_name=name))
         return system.components[component_index]

--- a/modules/core/kivent_core/systems/gamesystem.pyx
+++ b/modules/core/kivent_core/systems/gamesystem.pyx
@@ -281,7 +281,11 @@ cdef class GameSystem(CWidget):
         Args:
             component_index (unsigned int): the component_id to be removed.
         '''
+        entity = self.py_components[component_index]
+        cdef unsigned int entity_id = entity.entity_id
         self.clear_component(component_index)
+        cdef EntityManager entity_manager = self.gameworld.entity_manager
+        entity_manager.set_component(entity_id, -1, self.system_index)
         self.py_components[component_index] = None
         self.free_indices.append(component_index)
 

--- a/modules/core/kivent_core/systems/staticmemgamesystem.pyx
+++ b/modules/core/kivent_core/systems/staticmemgamesystem.pyx
@@ -16,7 +16,7 @@ from gamesystem cimport GameSystem
 from kivent_core.managers.system_manager cimport SystemManager
 from cpython cimport bool
 from kivent_core.memory_handlers.utils import memrange
-
+from kivent_core.managers.entity_manager cimport EntityManager
 
 
 cdef class MemComponent:
@@ -223,8 +223,13 @@ cdef class StaticMemGameSystem(GameSystem):
         Overrides the default behavior of GameSystem, passing data handling
         duties to the IndexedMemoryZone. **clear_component** will be called
         prior to calling **free_slot** on the MemoryZone.'''
-        self.clear_component(component_index)
         cdef MemoryZone memory_zone = self.imz_components.memory_zone
+        cdef EntityManager entity_manager = self.gameworld.entity_manager
+        cdef unsigned int *pointer = <unsigned int*>memory_zone.get_pointer(
+            component_index)
+        cdef unsigned int entity_id = pointer[0]
+        self.clear_component(component_index)
+        entity_manager.set_component(entity_id, -1, self.system_index)
         memory_zone.free_slot(component_index)
 
     def init_component(self, unsigned int component_index,


### PR DESCRIPTION
This fixes a bug where removed Components were still accessible after calling `gamesystem.remove_component()`.

Code to reproduce the error in the unpatched version:
```
        entities = self.gameworld.entities
        cid = entities[ent].get_component_index(some_system_name)
        self.gameworld.system_manager[some_system_name].remove_component(cid)
        print(getattr(entities[ent], some_system_name))
```

This will print `None` when `some_system_name` belongs to a GameSystem.
In case of a `StaticMemGameSystem` it will return a `MemComponent` which points to "freed"/cleared data.
With this PR both cases will raise a `NoComponentActiveError`.