### PR TITLE
Functions to get the active count of components and entities

### DIFF
--- a/modules/core/kivent_core/gameworld.pyx
+++ b/modules/core/kivent_core/gameworld.pyx
@@ -66,10 +66,6 @@ class GameWorld(Widget):
         control the current screen of the gamescreenmanager, as well as which
         systems are currently added or removed from canvas or paused.
 
-        **number_entities** (NumericProperty): This is the current number of
-        entities in the system. Do not modify directly, used to generate
-        entity_ids.
-
         **gamescreenmanager** (ObjectProperty): Reference to the
         GameScreenManager your game will use for UI screens.
 

--- a/modules/core/kivent_core/managers/entity_manager.pxd
+++ b/modules/core/kivent_core/managers/entity_manager.pxd
@@ -12,3 +12,5 @@ cdef class EntityManager(GameManager):
     cdef void remove_entity(self, unsigned int entity_id)
     cdef void set_entity_active(self, unsigned int entity_id)
     cdef unsigned int get_size(self)
+    cpdef unsigned int get_active_entity_count(self)
+    cpdef unsigned int get_active_entity_count_in_zone(self, str zone) except <unsigned int>-1

--- a/modules/core/kivent_core/managers/entity_manager.pyx
+++ b/modules/core/kivent_core/managers/entity_manager.pyx
@@ -168,3 +168,27 @@ cdef class EntityManager(GameManager):
         self.clear_entity(entity_id)
         cdef MemoryZone memory_zone = self.memory_index.memory_zone
         memory_zone.free_slot(entity_id)
+
+    cpdef unsigned int get_active_entity_count(self):
+        ''' Returns the number of all currently active entities.
+
+        **Return**:
+            unsigned int: active entity count.
+        '''
+        cdef MemoryZone memory_zone = self.memory_index.memory_zone
+        return memory_zone.get_active_slot_count()
+
+    cpdef unsigned int get_active_entity_count_in_zone(self, str zone) except <unsigned int>-1:
+        '''Returns the number of currently active entities for the given zone.
+
+        **Args**:
+            zone (str): The zone name.
+
+        **Return**:
+            unsigned int: active entity count in the given zone.
+
+        Will raise a **ValueError** exception if the given zone does not exists.
+        '''
+        cdef MemoryZone memory_zone = self.memory_index.memory_zone
+        cdef unsigned int pool_index = memory_zone.get_pool_index_from_name(zone) 
+        return memory_zone.get_active_slot_count_in_pool(pool_index)

--- a/modules/core/kivent_core/memory_handlers/indexing.pyx
+++ b/modules/core/kivent_core/memory_handlers/indexing.pyx
@@ -296,6 +296,41 @@ cdef class IndexedMemoryZone:
         else:
             return self.zone_index.get_component_from_index(value)
 
+    def get_active_count_in_zone(self, str zone):
+        '''Returns the count of all active components of this
+        **MemoryZone** for the given zone.
+
+        **Args**:
+            zone (str): The zone name.
+
+        **Return**:
+            int: active block count.
+
+        Will raise a **ValueError** exception if this **Memoryzone**
+        does not use the given zone.
+
+        .. note:: For Cython access use the \
+        :func:`kivent_core.memory_handlers.zone.MemoryZone.get_active_slot_count_in_pool` \
+            method in the :class:`kivent_core.memory_handlers.zone.MemoryZone` directly.
+        '''
+        cdef MemoryZone memory_zone = self.memory_zone
+        cdef unsigned int pool_index = memory_zone.get_pool_index_from_name(zone) 
+        return self.memory_zone.get_active_slot_count_in_pool(pool_index)
+      
+    def get_active_count(self):
+        ''' Returns the count of all active components
+        in all used zones.
+
+        **Return**:
+            int: The count of all active components.
+
+        .. note:: For Cython access use the \
+        :func:`kivent_core.memory_handlers.zone.MemoryZone.get_active_slot_count` \
+            method in the :class:`kivent_core.memory_handlers.zone.MemoryZone` directly.
+        '''
+        cdef MemoryZone memory_zone = self.memory_zone 
+        return self.memory_zone.get_active_slot_count()  
+
     cdef void* get_pointer(self, unsigned int index) except NULL:
         '''Returns a pointer to the data for the slot at index.
         Args:

--- a/modules/core/kivent_core/memory_handlers/zone.pxd
+++ b/modules/core/kivent_core/memory_handlers/zone.pxd
@@ -29,6 +29,8 @@ cdef class MemoryZone:
     cdef void* get_pointer(self, unsigned int index) except NULL
     cdef unsigned int get_pool_end_from_pool_index(self, unsigned int index)
     cdef tuple get_pool_range(self, unsigned int pool_index)
-    cdef unsigned int get_pool_index_from_name(self, str zone_name)
+    cdef unsigned int get_pool_index_from_name(self, str zone_name) except <unsigned int>-1
     cdef unsigned int get_pool_offset(self, unsigned int pool_index)
     cdef unsigned int get_size(self)
+    cdef unsigned int get_active_slot_count(self)
+    cdef unsigned int get_active_slot_count_in_pool(self, unsigned int pool_index) except <unsigned int>-1

--- a/modules/core/kivent_core/systems/gamesystem.pxd
+++ b/modules/core/kivent_core/systems/gamesystem.pxd
@@ -6,3 +6,5 @@ cdef class GameSystem(CWidget):
     cdef unsigned int component_count
     cdef object free_indices
     cdef dict copied_components
+    cpdef unsigned int get_active_component_count(self) except <unsigned int>-1
+    cpdef unsigned int get_active_component_count_in_zone(self, str zone) except <unsigned int>-1

--- a/modules/core/kivent_core/systems/gamesystem.pyx
+++ b/modules/core/kivent_core/systems/gamesystem.pyx
@@ -285,6 +285,22 @@ cdef class GameSystem(CWidget):
         self.py_components[component_index] = None
         self.free_indices.append(component_index)
 
+    cpdef unsigned int get_active_component_count(self) except <unsigned int>-1:
+        '''
+        Returns the number of active components in this system.
+        '''
+        return self.component_count - len(self.free_indices)
+
+    cpdef unsigned int get_active_component_count_in_zone(self, str zone) except <unsigned int>-1:
+        '''
+        Returns the number of active components of this system in the given zone.
+
+        Not implemented in the python GameSystem, but overwritten in
+        StaticMemGameSystems and other GameSystems supporting zones.
+        Calling this method on GameSystems which did not overwrite this function
+        will raise a **NotImplementedError**.
+        '''
+        raise NotImplementedError("The default python GameSystem does not support zones.")
 
     def on_remove_system(self):
         '''Function called when a system is removed during a gameworld state

--- a/modules/core/kivent_core/systems/staticmemgamesystem.pyx
+++ b/modules/core/kivent_core/systems/staticmemgamesystem.pyx
@@ -242,6 +242,33 @@ cdef class StaticMemGameSystem(GameSystem):
         recycling'''
         pass
 
+    cpdef unsigned int get_active_component_count(self) except <unsigned int>-1:
+        '''Returns the number of all active components in this system.
+
+        **Return:**
+            unsigned int: The number of active components.
+        '''
+        cdef IndexedMemoryZone indexed = self.imz_components
+        cdef MemoryZone memory_zone = indexed.memory_zone
+        return memory_zone.get_active_slot_count()
+    
+    cpdef unsigned int get_active_component_count_in_zone(self, str zone) except <unsigned int>-1:
+        '''Returns the number of active components of this system in the given zone.
+
+        **Args:**
+            zone (str): The name of the zone to get the count from.
+
+        **Return:**
+            unsigned int: The number of active components in the given zone.
+
+        Will raise a **ValueError** exception if this **GameSystem**
+        does not use the given zone.
+        '''
+        cdef IndexedMemoryZone indexed = self.imz_components
+        cdef MemoryZone memory_zone = indexed.memory_zone
+        cdef unsigned int pool_index = memory_zone.get_pool_index_from_name(zone) 
+        return memory_zone.get_active_slot_count_in_pool(pool_index)
+
 
 cdef class ZonedAggregator:
     '''


### PR DESCRIPTION
This PR adds functions to retrieve the count of the current active components/entities.

Added functions:
- **MemoryZone**
   - `get_active_slot_count` : (cdefed) Returns the count of all active elements in all zones.
   - `get_active_slot_count_in_pool` (cdefed): Returns the count of active elements in a given zone.
- **IndexedMemoryZone**
   - `get_active_count` :  Exposes `get_active_slot_count` to python
   - `get_active_count_in_zone` : Exposes `get_active_slot_count_in_pool` to python
- **EntityManager**
   - `get_active_entity_count` : Exposes `get_active_slot_count` to python
   - `get_active_entity_count_in_zone` : Exposes `get_active_slot_count_in_pool` to python
- **GameSystem** and **StaticMemGameSystem**
   - `get_active_component_count` : Exposes `get_active_slot_count` to python in the **StaticMemGameSystem** and calculates the correct count in **GameSystem**.
   - `get_active_component_count_in_zone` : Exposes `get_active_slot_count_in_pool` to python in the **StaticMemGameSystem** and raises an Error in the **GameSystem** as it doesn't handle zones.

This allows to get the count from python like:
```
entities = entity_manager.get_active_component_count()
# The same as 
entities = gameworld.entities.get_active_count()

```
and
```
components = system_manager[system].get_active_component_count()
# For StaticMemGameSystems the same as
components = system_manager[system].components.get_active_count()
```

I also removed the comment in `Gameworld` regarding `number_entities` as this attribute doesn't exist (anymore ?).