### PR TITLE
Fixes memory leak in FixedVBO ( Issue #179 )

### DIFF
--- a/modules/core/kivent_core/rendering/fixedvbo.pyx
+++ b/modules/core/kivent_core/rendering/fixedvbo.pyx
@@ -163,14 +163,13 @@ cdef class FixedVBO:
     cdef void reload(self):
         '''Will flag this VBO as V_NEEDGEN, set the **size_last_frame** to 0,
         and clear the **memory_block**.'''
-        self.flags = V_NEEDGEN
         self.size_last_frame = 0
         cdef Context context = get_context()
         if self.have_id():
             arr = context.lr_vbo
             arr.append(self.id)
             context.trigger_gl_dealloc()
-            self.flags |= ~V_HAVEID
+        self.flags = V_NEEDGEN
         if self.target == GL_ELEMENT_ARRAY_BUFFER:
             self.data_size = 0
         self.memory_block.clear()


### PR DESCRIPTION
Fix memory leak referenced in Issue #179.

The `FixedVBO.reload` method did set `flag` to `V_NEEDGEN` before calling `self.have_id()` which checks if `self.flag`s `V_HAVEID` bit is set and thus always returned false.
