### PR TITLE
Ensured that componets added after initialization are handled correctly.

### DIFF
--- a/modules/core/kivent_core/entity.pxd
+++ b/modules/core/kivent_core/entity.pxd
@@ -4,6 +4,7 @@ from kivent_core.managers.system_manager cimport SystemManager
 cdef class Entity(MemComponent):
     cdef list _load_order
     cdef SystemManager system_manager
-    cdef void set_component(self, unsigned int component_id,
-        unsigned int system_id)
+    cdef int set_component(self, unsigned int component_id,
+        unsigned int system_index) except 0
     cpdef unsigned int get_component_index(self, str name)
+    cdef unsigned int get_component_index_c(self, unsigned int system_index)

--- a/modules/core/kivent_core/managers/entity_manager.pxd
+++ b/modules/core/kivent_core/managers/entity_manager.pxd
@@ -6,8 +6,8 @@ cdef class EntityManager(GameManager):
     cdef unsigned int system_count
 
     cdef void clear_entity(self, unsigned int entity_id)
-    cdef void set_component(self, unsigned int entity_id,
-        unsigned int component_id, unsigned int system_id)
+    cdef int set_component(self, unsigned int entity_id,
+        unsigned int component_id, unsigned int system_id) except 0
     cdef unsigned int generate_entity(self, str zone) except -1
     cdef void remove_entity(self, unsigned int entity_id)
     cdef void set_entity_active(self, unsigned int entity_id)

--- a/modules/core/kivent_core/managers/entity_manager.pyx
+++ b/modules/core/kivent_core/managers/entity_manager.pyx
@@ -79,8 +79,8 @@ cdef class EntityManager(GameManager):
         '''
         return self.memory_index.get_size()
 
-    cdef void set_component(self, unsigned int entity_id,
-        unsigned int component_id, unsigned int system_id):
+    cdef int set_component(self, unsigned int entity_id,
+        unsigned int component_id, unsigned int system_id) except 0:
         '''
         Sets the component_id for the system at system_id in the
         entity data for Entity entity_id. Typically called by the GameSystem
@@ -98,11 +98,9 @@ cdef class EntityManager(GameManager):
             system_id (usngined int): index of the GameSystem.
 
         '''
-
-        cdef MemoryZone memory_zone = self.memory_index.memory_zone
-        cdef unsigned int* pointer = <unsigned int*>(
-            memory_zone.get_pointer(entity_id))
-        pointer[system_id+1] = component_id
+        cdef Entity entity = self.memory_index[entity_id]
+        entity.set_component(component_id, system_id)
+        return 1
 
     cdef void set_entity_active(self, unsigned int entity_id):
         '''


### PR DESCRIPTION
There are multiple problems regarding components added by `create_component` / removed by `remove_component`.

**Components created via `create_component` aren't removed at the `gameworld.remove_entity` call.**
```
        gameworld.clear_entities()
        system = gameworld.system_manager['position']
        ent = gameworld.init_entity({'rotate':0}, ['rotate'])
        system.create_component(ent, 'general', (0,0))
        self.gameworld.remove_entity(ent)
        assert system.get_active_component_count() == 0
```

**Initial components removed by `remove_component` lead to a crash at `gameworld.remove_entity`.**
```
        gameworld.clear_entities()
        system = gameworld.system_manager['position']
        ent = gameworld.init_entity({'rotate':0, 'position':(0,0)}, ['rotate','position'])
        cind = gameworld.entities[ent].get_component_index('position')
        system.remove_component(cind)
        self.gameworld.remove_entity(ent)
```

**Duplicate components lead to memory leaks as the second component will overwrite the first one without any warning whatsoever.**

        gameworld.clear_entities()
        system = gameworld.system_manager['position']
        ent = gameworld.init_entity({'rotate':0, 'position':(0,0)}, ['rotate','position'])
        system.create_component(ent, 'general', (0,0))
        self.gameworld.remove_entity(ent)
        assert system.get_active_component_count() == 0
```

This PR fixes/prevents all the mentioned cases.

**Changes:**
- Changed the `EntityManager.set_component` method to call `Entity.set_component` so the `load_order` can be updated. Not super happy about this but i think its the best backwards compatible way to do this.
- The `Entity.set_component` function checks if the system is already in the `load_order` and otherwise adds it. This makes component initialization a little bit slower because we need to search in the `load_order` list. This could be optimized, but according to my benchmarks it doesn't really matter.
- The `Entity.set_component` function will now raise a `DuplicateComponentError` if there is already a component from the system active.
- The Entities `load_order` now saves the system indices instead of the names as all the places using them need the system index anyway.
- The Entities `load_order` property still returns the system_names but i removed the setter as changing them directly is just asking for trouble IMHO.


