### PR TITLE
Expose cymunk layers + offset for BoxShape

### DIFF
--- a/modules/cymunk/kivent_cymunk/physics.pxd
+++ b/modules/cymunk/kivent_cymunk/physics.pxd
@@ -1,4 +1,4 @@
-from cymunk.cymunk cimport Body, cpBody, Space
+from cymunk.cymunk cimport Body, cpBody, Space, cpLayers
 from kivent_core.systems.staticmemgamesystem cimport (StaticMemGameSystem,
     MemComponent)
 
@@ -20,7 +20,16 @@ cdef class CymunkPhysics(StaticMemGameSystem):
     cdef list segment_query_result
     cdef int collision_type_count
     cdef dict collision_type_index
+    cdef readonly LayerHelper layers
 
     cdef unsigned int _init_component(self, unsigned int component_index,
         unsigned int entity_id, cpBody* body, str zone_name) except -1
     cdef int _clear_component(self, unsigned int component_index) except 0
+
+
+cdef class LayerHelper:
+    cdef list layers
+    cdef dict _layer_ids
+    cdef int _max_size
+    cdef readonly cpLayers ALL_LAYERS, NO_LAYERS
+    cpdef cpLayers calculate_layerset(self, object used_layer) except *


### PR DESCRIPTION
This PR mainly exposes the cymunk layers and the offset for BoxShapes (https://github.com/kivy/cymunk/pull/49).
This PR will break BoxShapes for user with old cymunk versions (before the above PR) !
It might be wise to split this PR into two ?

To make using the layers (a bitset) a bit easier i added the `LayerHelper` class which allows mapping of layer names to bits.
The `shape_info` dict may now contain a `layers` key which holds an iterable of registered layer names or an int representing the bitset.
I am not sure if the `LayerHelper` should live in kivent or cymunk.

*Other changes:*
- Made all offsets optional. Defaulting to `(0,0)`
- Removed outdated info from `init_component`s doc string.
- 
