### PR TITLE
Pass mag_filter opt through texture_manager loaders

### DIFF
--- a/modules/core/kivent_core/managers/resource_managers.pyx
+++ b/modules/core/kivent_core/managers/resource_managers.pyx
@@ -581,8 +581,9 @@ cdef class TextureManager(GameManager):
         def __get__(self):
             return [key for key in self._keys]
 
-    def load_image(self, source):
+    def load_image(self, source, mag_filter='linear'):
         texture = CoreImage(source, nocache=True).texture
+        texture.mag_filter = mag_filter
         name = path.splitext(path.basename(source))[0]
         name = str(name)
         if name in self._keys:
@@ -670,7 +671,7 @@ cdef class TextureManager(GameManager):
     def get_texkey_in_group(self, tex_key, group_key):
         return tex_key in self._groups[group_key]
 
-    def load_atlas(self, source, datatype='json', dirname=None):
+    def load_atlas(self, source, datatype='json', dirname=None, mag_filter='linear'):
         if datatype == 'json':
             dirname = path.dirname(source)
             with open(source, 'r') as data:
@@ -683,6 +684,7 @@ cdef class TextureManager(GameManager):
         for imgname in atlas_data:
             texture = CoreImage(
                 path.join(dirname,imgname), nocache=True).texture
+            texture.mag_filter = mag_filter
             name = str(path.basename(imgname))
             size = texture.size
             w = <float>size[0]


### PR DESCRIPTION
# Rationale
The KivEnt gamescreen system supports arbitrary scrolling, which is awesome and opens up really cool game modes like pixel art based games. And the underlying Kivy texture class supports selecting magnification filters for your textures [here](https://github.com/kivy/kivy/blob/master/kivy/graphics/texture.pyx#L1268-L1283), with an example of this happening in the wild on this [Stack Overflow post](https://stackoverflow.com/questions/47396563/in-kivy-how-do-i-prevent-pixel-images-from-becoming-blurry-when-enlarged).

However, KivEnt's texture loader defaults to the 'linear' magnification filter, which leads to uninspiring closeups for sprites as the linear filter will blur edges.

The goal of this work is to allow the texture manager to configure `mag_filter` on the fly, letting users set the filter to 'nearest' which leads to sharp pixels.

# Changes
Adds a kwarg to the TextureManager's classes :meth`load_image` and :meth`load_atlas`, which allows specifying mag_filter. This is passed through to any images loaded via an atlas.

# Examples

## Default; Linear Mag Filter
```
texture_manager.load_atlas('background_objects.atlas'))
```
![image](https://user-images.githubusercontent.com/5408531/67062314-ea1cf000-f130-11e9-9201-9998e767a19b.png)


## This PR; Nearest Mag Filter Specified
```
texture_manager.load_atlas('background_objects.atlas', mag_filter='nearest')
```
![image](https://user-images.githubusercontent.com/5408531/67062528-85ae6080-f131-11e9-91aa-110832bdf46d.png)

(If no mag_filter is specified, the the loader defaults to linear).