### PR TITLE
Add support for detecting Apple Silicon (arm64) architecture on macOS

### DIFF
--- a/modules/core/setup.py
+++ b/modules/core/setup.py
@@ -63,7 +63,13 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    if sys.maxsize > 2 ** 32:
+    import platform as _pf
+
+    machine = _pf.machine()
+
+    if machine == 'arm64':
+        osx_arch = 'arm64'
+    elif sys.maxsize > 2 ** 32:
         osx_arch = 'x86_64'
     else:
         osx_arch = 'i386'

--- a/modules/core/setup.py
+++ b/modules/core/setup.py
@@ -1,15 +1,16 @@
 from os import environ, remove
-from platform import uname
-from os.path import join, isfile, exists
+from os.path import exists, isfile, join
+
 import kivy
-from subprocess import check_output
 
 if environ.get('KIVENT_USE_SETUPTOOLS'):
-    from setuptools import setup, Extension
+    from setuptools import Extension, setup
+
     print('Using setuptools')
 else:
     from distutils.core import setup
     from distutils.extension import Extension
+
     print('Using distutils')
 
 try:
@@ -42,9 +43,11 @@ elif environ.get('KIVYIOSROOT'):
     extra_link_args = ['-isysroot', sysroot, '-framework', 'OpenGLES']
 elif exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
-    global_include_dirs = ['/opt/vc/include',
-                           '/opt/vc/include/interface/vcos/pthreads',
-                           '/opt/vc/include/interface/vmcs_host/linux']
+    global_include_dirs = [
+        '/opt/vc/include',
+        '/opt/vc/include/interface/vcos/pthreads',
+        '/opt/vc/include/interface/vmcs_host/linux',
+    ]
     library_dirs = ['/opt/vc/lib']
     libraries = ['bcm_host', 'EGL', 'GLESv2']
 elif exists('/usr/lib/arm-linux-gnueabihf/libMali.so'):
@@ -63,32 +66,8 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    import platform as _pf
-
-    machine = _pf.machine()
-
-    if machine == 'arm64':
-        osx_arch = 'arm64'
-    elif sys.maxsize > 2 ** 32:
-        osx_arch = 'x86_64'
-    else:
-        osx_arch = 'i386'
-    v = uname()
-    if v[2] >= '13.0.0':
-        import platform as _platform
-
-        xcode_dev = check_output(['xcode-select', '-p']).decode().strip()
-        sdk_mac_ver = '.'.join(_platform.mac_ver()[0].split('.')[:2])
-        sysroot = join(xcode_dev,
-                       'Platforms/MacOSX.platform/Developer/SDKs',
-                       'MacOSX{}.sdk'.format(sdk_mac_ver),
-                       'System/Library/Frameworks')
-    else:
-        sysroot = ('/System/Library/Frameworks/'
-                   'ApplicationServices.framework/Frameworks')
-    extra_compile_args = ['-F' + sysroot, '-arch', osx_arch]
-    extra_link_args = ['-F' + sysroot, '-arch', osx_arch,
-                       '-framework', 'OpenGL']
+    extra_compile_args = []
+    extra_link_args = ['-framework', 'OpenGL', '-framework', 'ApplicationServices']
     libraries = []
 
 do_clear_existing = False
@@ -99,7 +78,7 @@ prefixes = {
     'rendering': 'kivent_core.rendering.',
     'managers': 'kivent_core.managers.',
     'uix': 'kivent_core.uix.',
-    'systems': 'kivent_core.systems.'
+    'systems': 'kivent_core.systems.',
 }
 
 file_prefixes = {
@@ -108,29 +87,55 @@ file_prefixes = {
     'rendering': 'kivent_core/rendering/',
     'managers': 'kivent_core/managers/',
     'uix': 'kivent_core/uix/',
-    'systems': 'kivent_core/systems/'
+    'systems': 'kivent_core/systems/',
 }
 
 modules = {
     'core': ['entity', 'gameworld'],
     'memory_handlers': [
-        'block', 'membuffer', 'indexing', 'pool', 'utils',
-        'zone', 'tests', 'zonedblock'
+        'block',
+        'membuffer',
+        'indexing',
+        'pool',
+        'utils',
+        'zone',
+        'tests',
+        'zonedblock',
     ],
     'rendering': [
-        'gl_debug', 'vertex_format', 'fixedvbo', 'cmesh', 'batching',
-        'vertex_format', 'frame_objects', 'vertex_formats', 'model',
-        'svg_loader', 'animation',
+        'gl_debug',
+        'vertex_format',
+        'fixedvbo',
+        'cmesh',
+        'batching',
+        'vertex_format',
+        'frame_objects',
+        'vertex_formats',
+        'model',
+        'svg_loader',
+        'animation',
     ],
     'managers': [
-        'resource_managers', 'system_manager', 'entity_manager',
-        'sound_manager', 'game_manager', 'animation_manager',
+        'resource_managers',
+        'system_manager',
+        'entity_manager',
+        'sound_manager',
+        'game_manager',
+        'animation_manager',
     ],
     'uix': ['cwidget', 'gamescreens'],
     'systems': [
-        'gamesystem', 'staticmemgamesystem', 'position_systems',
-        'gameview', 'scale_systems', 'rotate_systems', 'color_systems',
-        'gamemap', 'renderers', 'lifespan', 'animation_sys',
+        'gamesystem',
+        'staticmemgamesystem',
+        'position_systems',
+        'gameview',
+        'scale_systems',
+        'rotate_systems',
+        'color_systems',
+        'gamemap',
+        'renderers',
+        'lifespan',
+        'animation_sys',
     ],
 }
 
@@ -148,22 +153,27 @@ for name in modules:
         check_for_removal.append(file_prefix + module_name + '.c')
 
 
-def build_ext(ext_name, files, include_dirs=[]):
-    return Extension(ext_name, files, global_include_dirs + include_dirs,
-                     extra_compile_args=[cstdarg, '-ffast-math', ] + extra_compile_args,
-                     libraries=libraries, extra_link_args=extra_link_args,
-                     library_dirs=library_dirs)
+def build_ext(ext_name, files):
+    return Extension(
+        ext_name,
+        files,
+        global_include_dirs + kivy.get_includes(),
+        extra_compile_args=[cstdarg, '-ffast-math'] + extra_compile_args,
+        libraries=libraries,
+        extra_link_args=extra_link_args,
+        library_dirs=library_dirs,
+    )
 
 
 extensions = []
 cymunk_extensions = []
 cmdclass = {}
 
+
 def build_extensions_for_modules_cython(ext_list, modules):
     ext_a = ext_list.append
     for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-                        include_dirs=kivy.get_includes())
+        ext = build_ext(module_name, modules[module_name])
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
@@ -173,8 +183,7 @@ def build_extensions_for_modules_cython(ext_list, modules):
 def build_extensions_for_modules(ext_list, modules):
     ext_a = ext_list.append
     for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-                        include_dirs=kivy.get_includes())
+        ext = build_ext(module_name, modules[module_name])
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
@@ -186,16 +195,15 @@ if have_cython:
         for file_name in check_for_removal:
             if isfile(file_name):
                 remove(file_name)
-    core_extensions = build_extensions_for_modules_cython(
-        extensions, core_modules)
+    core_extensions = build_extensions_for_modules_cython(extensions, core_modules)
 else:
     core_extensions = build_extensions_for_modules(extensions, core_modules_c)
 
 setup(
     name='KivEnt Core',
     version='3.0.0',
-    description='''A game engine for the Kivy Framework.
-        https://github.com/Kovak/KivEnt for more info.''',
+    description="""A game engine for the Kivy Framework.
+        https://github.com/Kovak/KivEnt for more info.""",
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
     ext_modules=core_extensions,
@@ -206,16 +214,17 @@ setup(
         'kivent_core.rendering',
         'kivent_core.managers',
         'kivent_core.systems',
-        'kivent_core.uix'
+        'kivent_core.uix',
     ],
     package_dir={'kivent_core': 'kivent_core'},
-    package_data={'kivent_core': [
-        '*.pxd',
-        'memory_handlers/*.pxd',
-        'rendering/*.pxd',
-        'managers/*.pxd',
-        'systems/*.pxd',
-        'uix/*.pxd'
-    ]
-    }
+    package_data={
+        'kivent_core': [
+            '*.pxd',
+            'memory_handlers/*.pxd',
+            'rendering/*.pxd',
+            'managers/*.pxd',
+            'systems/*.pxd',
+            'uix/*.pxd',
+        ]
+    },
 )

--- a/modules/cymunk/setup.py
+++ b/modules/cymunk/setup.py
@@ -1,15 +1,14 @@
-import pkgutil
 from os import environ, remove
-from platform import uname
-from os.path import join, isfile, exists, dirname
-from subprocess import check_output
+from os.path import exists, isfile, join
 
 if environ.get('KIVENT_USE_SETUPTOOLS'):
-    from setuptools import setup, Extension
+    from setuptools import Extension, setup
+
     print('Using setuptools')
 else:
     from distutils.core import setup
     from distutils.extension import Extension
+
     print('Using distutils')
 
 try:
@@ -41,9 +40,11 @@ elif environ.get('KIVYIOSROOT'):
     extra_link_args = ['-isysroot', sysroot, '-framework', 'OpenGLES']
 elif exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
-    global_include_dirs = ['/opt/vc/include',
-                           '/opt/vc/include/interface/vcos/pthreads',
-                           '/opt/vc/include/interface/vmcs_host/linux']
+    global_include_dirs = [
+        '/opt/vc/include',
+        '/opt/vc/include/interface/vcos/pthreads',
+        '/opt/vc/include/interface/vmcs_host/linux',
+    ]
     library_dirs = ['/opt/vc/lib']
     libraries = ['bcm_host', 'EGL', 'GLESv2']
 elif exists('/usr/lib/arm-linux-gnueabihf/libMali.so'):
@@ -62,67 +63,48 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    import platform as _pf
-
-    machine = _pf.machine()
-
-    if machine == 'arm64':
-        osx_arch = 'arm64'
-    elif sys.maxsize > 2 ** 32:
-        osx_arch = 'x86_64'
-    else:
-        osx_arch = 'i386'
-    v = uname()
-    if v[2] >= '13.0.0':
-        import platform as _platform
-
-        xcode_dev = check_output(['xcode-select', '-p']).decode().strip()
-        sdk_mac_ver = '.'.join(_platform.mac_ver()[0].split('.')[:2])
-        sysroot = join(xcode_dev,
-                       'Platforms/MacOSX.platform/Developer/SDKs',
-                       'MacOSX{}.sdk'.format(sdk_mac_ver),
-                       'System/Library/Frameworks')
-    else:
-        sysroot = ('/System/Library/Frameworks/'
-                   'ApplicationServices.framework/Frameworks')
-    extra_compile_args = ['-F' + sysroot, '-arch', osx_arch]
-    extra_link_args = ['-F' + sysroot, '-arch', osx_arch,
-                       '-framework', 'OpenGL']
+    extra_compile_args = []
+    extra_link_args = ['-framework', 'OpenGL', '-framework', 'ApplicationServices']
     libraries = []
 
 do_clear_existing = True
 
-# import cymunk
+import cymunk
 
 cymunk_modules = {
-    'kivent_cymunk.physics': ['kivent_cymunk/physics.pyx', ],
-    'kivent_cymunk.interaction': ['kivent_cymunk/interaction.pyx', ],
+    'kivent_cymunk.physics': [
+        'kivent_cymunk/physics.pyx',
+    ],
+    'kivent_cymunk.interaction': [
+        'kivent_cymunk/interaction.pyx',
+    ],
 }
 
 cymunk_modules_c = {
-    'kivent_cymunk.physics': ['kivent_cymunk/physics.c', ],
-    'kivent_cymunk.interaction': ['kivent_cymunk/interaction.c', ],
+    'kivent_cymunk.physics': [
+        'kivent_cymunk/physics.c',
+    ],
+    'kivent_cymunk.interaction': [
+        'kivent_cymunk/interaction.c',
+    ],
 }
 
 check_for_removal = [
     'kivent_cymunk/physics.c',
     'kivent_cymunk/interaction.c',
-
 ]
 
-loader = pkgutil.get_loader("cymunk")
-cymunk_dirname = loader.path if hasattr(loader, 'path') else loader.filename
 
-# pkgutil gives different results for py3
-if '__init__.py' in cymunk_dirname:
-    cymunk_dirname = dirname(cymunk_dirname)
-
-
-def build_ext(ext_name, files, include_dirs=[cymunk_dirname]):
-    return Extension(ext_name, files, global_include_dirs + include_dirs,
-                     extra_compile_args=[cstdarg, '-ffast-math', ] + extra_compile_args,
-                     libraries=libraries, extra_link_args=extra_link_args,
-                     library_dirs=library_dirs)
+def build_ext(ext_name, files):
+    return Extension(
+        ext_name,
+        files,
+        global_include_dirs + cymunk.get_includes(),
+        extra_compile_args=[cstdarg, '-ffast-math'] + extra_compile_args,
+        libraries=libraries,
+        extra_link_args=extra_link_args,
+        library_dirs=library_dirs,
+    )
 
 
 extensions = []
@@ -137,7 +119,7 @@ def build_extensions_for_modules_cython(ext_list, modules):
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
-    return cythonize(ext_list, compiler_directives={'language_level' : "3"})
+    return cythonize(ext_list, compiler_directives={'language_level': '3'})
 
 
 def build_extensions_for_modules(ext_list, modules):
@@ -156,23 +138,23 @@ if have_cython:
             if isfile(file_name):
                 remove(file_name)
     cymunk_extensions = build_extensions_for_modules_cython(
-        cymunk_extensions, cymunk_modules)
+        cymunk_extensions, cymunk_modules
+    )
 else:
-    cymunk_extensions = build_extensions_for_modules(cymunk_extensions,
-                                                     cymunk_modules_c)
+    cymunk_extensions = build_extensions_for_modules(
+        cymunk_extensions, cymunk_modules_c
+    )
 
 setup(
     name='KivEnt Cymunk',
     version='2.0.0',
-    description='''A game engine for the Kivy Framework.
-        https://github.com/Kovak/KivEnt for more info.''',
+    description="""A game engine for the Kivy Framework.
+        https://github.com/Kovak/KivEnt for more info.""",
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
     ext_modules=cymunk_extensions,
     cmdclass=cmdclass,
-    packages=[
-        'kivent_cymunk',
-    ],
+    packages=['kivent_cymunk'],
     package_dir={'kivent_cymunk': 'kivent_cymunk'},
-    package_data={'kivent_cymunk': ['*.pxd', ]}
+    package_data={'kivent_cymunk': ['*.pxd']},
 )

--- a/modules/cymunk/setup.py
+++ b/modules/cymunk/setup.py
@@ -62,7 +62,13 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    if sys.maxsize > 2 ** 32:
+    import platform as _pf
+
+    machine = _pf.machine()
+
+    if machine == 'arm64':
+        osx_arch = 'arm64'
+    elif sys.maxsize > 2 ** 32:
         osx_arch = 'x86_64'
     else:
         osx_arch = 'i386'

--- a/modules/maps/kivent_maps/map_manager.pyx
+++ b/modules/maps/kivent_maps/map_manager.pyx
@@ -70,8 +70,6 @@ cdef class MapManager(GameManager):
             orientation (str): Orientation of the map tiles. Can be one of
             'orthogonal', 'staggered', 'hexagonal', 'isometric'
         '''
-        if PY2:
-            name = name.encode('utf-8')
         cdef TileMap tile_map
         cdef list largs = [map_size_x, map_size_y,
                            tile_layers, object_count,

--- a/modules/maps/setup.py
+++ b/modules/maps/setup.py
@@ -1,18 +1,22 @@
 from os import environ, remove
-from os.path import dirname, join, isfile
+from os.path import isfile
+
 import kivy
 
 if environ.get('KIVENT_USE_SETUPTOOLS'):
-    from setuptools import setup, Extension
+    from setuptools import Extension, setup
+
     print('Using setuptools')
 else:
     from distutils.core import setup
     from distutils.extension import Extension
+
     print('Using distutils')
 
 try:
     from Cython.Build import cythonize
     from Cython.Distutils import build_ext
+
     have_cython = True
 except ImportError:
     have_cython = False
@@ -21,7 +25,7 @@ import sys
 platform = sys.platform
 if platform == 'win32':
     cstdarg = '-std=gnu99'
-    libraries = ['opengl32', 'glu32','glew32']
+    libraries = ['opengl32', 'glu32', 'glew32']
 else:
     cstdarg = '-std=c99'
     libraries = []
@@ -30,17 +34,28 @@ else:
 do_clear_existing = True
 
 
-
 particles_modules = {
-    'kivent_maps.map_data': ['kivent_maps/map_data.pyx',],
-    'kivent_maps.map_system': ['kivent_maps/map_system.pyx',],
-    'kivent_maps.map_manager': ['kivent_maps/map_manager.pyx',],
+    'kivent_maps.map_data': [
+        'kivent_maps/map_data.pyx',
+    ],
+    'kivent_maps.map_system': [
+        'kivent_maps/map_system.pyx',
+    ],
+    'kivent_maps.map_manager': [
+        'kivent_maps/map_manager.pyx',
+    ],
 }
 
 particles_modules_c = {
-    'kivent_maps.map_data': ['kivent_maps/map_data.c',],
-    'kivent_maps.map_system': ['kivent_maps/map_system.c',],
-    'kivent_maps.map_manager': ['kivent_maps/map_manager.c',],
+    'kivent_maps.map_data': [
+        'kivent_maps/map_data.c',
+    ],
+    'kivent_maps.map_system': [
+        'kivent_maps/map_system.c',
+    ],
+    'kivent_maps.map_manager': [
+        'kivent_maps/map_manager.c',
+    ],
 }
 
 check_for_removal = [
@@ -49,34 +64,41 @@ check_for_removal = [
     'kivent_maps/map_manager.c',
 ]
 
-def build_ext(ext_name, files, include_dirs=[]):
-    return Extension(ext_name, files, include_dirs,
-        extra_compile_args=[cstdarg, '-ffast-math',],
-        libraries=libraries,)
+
+def build_ext(ext_name, files):
+    return Extension(
+        ext_name,
+        files,
+        kivy.get_includes(),
+        extra_compile_args=[cstdarg, '-ffast-math'],
+        libraries=libraries,
+    )
+
 
 extensions = []
 particles_extensions = []
 cmdclass = {}
 
+
 def build_extensions_for_modules_cython(ext_list, modules):
     ext_a = ext_list.append
     for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-            include_dirs=kivy.get_includes())
+        ext = build_ext(module_name, modules[module_name])
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
-    return cythonize(ext_list, compiler_directives={'language_level' : "3"})
+    return cythonize(ext_list, compiler_directives={'language_level': '3'})
+
 
 def build_extensions_for_modules(ext_list, modules):
     ext_a = ext_list.append
     for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-            include_dirs=kivy.get_includes())
+        ext = build_ext(module_name, modules[module_name])
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
     return ext_list
+
 
 if have_cython:
     if do_clear_existing:
@@ -84,23 +106,23 @@ if have_cython:
             if isfile(file_name):
                 remove(file_name)
     particles_extensions = build_extensions_for_modules_cython(
-        particles_extensions, particles_modules)
+        particles_extensions, particles_modules
+    )
 else:
-    particles_extensions = build_extensions_for_modules(particles_extensions,
-        particles_modules_c)
-
+    particles_extensions = build_extensions_for_modules(
+        particles_extensions, particles_modules_c
+    )
 
 
 setup(
     name='KivEnt maps',
     version='3.0.0',
-    description='''Module to render maps in the KivEnt game engine
-    along with Tiled maps support.''',
+    description="""Module to render maps in the KivEnt game engine
+    along with Tiled maps support.""",
     author='Meet Udeshi',
     author_email='mudeshi1209@gmail.com',
     ext_modules=particles_extensions,
     cmdclass=cmdclass,
-    packages=[
-        'kivent_maps',
-        ],
-    package_dir={'kivent_maps': 'kivent_maps'})
+    packages=['kivent_maps'],
+    package_dir={'kivent_maps': 'kivent_maps'},
+)

--- a/modules/particles/setup.py
+++ b/modules/particles/setup.py
@@ -63,7 +63,13 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    if sys.maxsize > 2 ** 32:
+    import platform as _pf
+
+    machine = _pf.machine()
+
+    if machine == 'arm64':
+        osx_arch = 'arm64'
+    elif sys.maxsize > 2 ** 32:
         osx_arch = 'x86_64'
     else:
         osx_arch = 'i386'

--- a/modules/particles/setup.py
+++ b/modules/particles/setup.py
@@ -1,16 +1,16 @@
 from os import environ, remove
-from platform import uname
-from os.path import join, isfile, exists
-from subprocess import check_output
+from os.path import exists, isfile, join
 
 import kivy
 
 if environ.get('KIVENT_USE_SETUPTOOLS'):
-    from setuptools import setup, Extension
+    from setuptools import Extension, setup
+
     print('Using setuptools')
 else:
     from distutils.core import setup
     from distutils.extension import Extension
+
     print('Using distutils')
 
 try:
@@ -42,9 +42,11 @@ elif environ.get('KIVYIOSROOT'):
     extra_link_args = ['-isysroot', sysroot, '-framework', 'OpenGLES']
 elif exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
-    global_include_dirs = ['/opt/vc/include',
-                           '/opt/vc/include/interface/vcos/pthreads',
-                           '/opt/vc/include/interface/vmcs_host/linux']
+    global_include_dirs = [
+        '/opt/vc/include',
+        '/opt/vc/include/interface/vcos/pthreads',
+        '/opt/vc/include/interface/vmcs_host/linux',
+    ]
     library_dirs = ['/opt/vc/lib']
     libraries = ['bcm_host', 'EGL', 'GLESv2']
 elif exists('/usr/lib/arm-linux-gnueabihf/libMali.so'):
@@ -63,39 +65,17 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    import platform as _pf
-
-    machine = _pf.machine()
-
-    if machine == 'arm64':
-        osx_arch = 'arm64'
-    elif sys.maxsize > 2 ** 32:
-        osx_arch = 'x86_64'
-    else:
-        osx_arch = 'i386'
-    v = uname()
-    if v[2] >= '13.0.0':
-        import platform as _platform
-
-        xcode_dev = check_output(['xcode-select', '-p']).decode().strip()
-        sdk_mac_ver = '.'.join(_platform.mac_ver()[0].split('.')[:2])
-        sysroot = join(xcode_dev,
-                       'Platforms/MacOSX.platform/Developer/SDKs',
-                       'MacOSX{}.sdk'.format(sdk_mac_ver),
-                       'System/Library/Frameworks')
-    else:
-        sysroot = ('/System/Library/Frameworks/'
-                   'ApplicationServices.framework/Frameworks')
-    extra_compile_args = ['-F' + sysroot, '-arch', osx_arch]
-    extra_link_args = ['-F' + sysroot, '-arch', osx_arch,
-                       '-framework', 'OpenGL']
+    extra_compile_args = []
+    extra_link_args = ['-framework', 'OpenGL', '-framework', 'ApplicationServices']
     libraries = []
 
 do_clear_existing = True
 
 particles_modules = {
     'kivent_particles.particle': ['kivent_particles/particle.pyx'],
-    'kivent_particles.emitter': ['kivent_particles/emitter.pyx', ],
+    'kivent_particles.emitter': [
+        'kivent_particles/emitter.pyx',
+    ],
     'kivent_particles.particle_formats': [
         'kivent_particles/particle_formats.pyx',
     ],
@@ -105,8 +85,12 @@ particles_modules = {
 }
 
 particles_modules_c = {
-    'kivent_particles.particle': ['kivent_particles/particle.c', ],
-    'kivent_particles.emitter': ['kivent_particles/emitter.c', ],
+    'kivent_particles.particle': [
+        'kivent_particles/particle.c',
+    ],
+    'kivent_particles.emitter': [
+        'kivent_particles/emitter.c',
+    ],
     'kivent_particles.particle_formats': [
         'kivent_particles/particle_formats.c',
     ],
@@ -123,11 +107,16 @@ check_for_removal = [
 ]
 
 
-def build_ext(ext_name, files, include_dirs=[]):
-    return Extension(ext_name, files, global_include_dirs + include_dirs,
-                     extra_compile_args=[cstdarg, '-ffast-math', ] + extra_compile_args,
-                     libraries=libraries, extra_link_args=extra_link_args,
-                     library_dirs=library_dirs)
+def build_ext(ext_name, files):
+    return Extension(
+        ext_name,
+        files,
+        global_include_dirs + kivy.get_includes(),
+        extra_compile_args=[cstdarg, '-ffast-math'] + extra_compile_args,
+        libraries=libraries,
+        extra_link_args=extra_link_args,
+        library_dirs=library_dirs,
+    )
 
 
 extensions = []
@@ -138,19 +127,17 @@ cmdclass = {}
 def build_extensions_for_modules_cython(ext_list, modules):
     ext_a = ext_list.append
     for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-                        include_dirs=kivy.get_includes())
+        ext = build_ext(module_name, modules[module_name])
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
-    return cythonize(ext_list, compiler_directives={'language_level' : "3"})
+    return cythonize(ext_list, compiler_directives={'language_level': '3'})
 
 
 def build_extensions_for_modules(ext_list, modules):
     ext_a = ext_list.append
     for module_name in modules:
-        ext = build_ext(module_name, modules[module_name],
-                        include_dirs=kivy.get_includes())
+        ext = build_ext(module_name, modules[module_name])
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
@@ -163,16 +150,18 @@ if have_cython:
             if isfile(file_name):
                 remove(file_name)
     particles_extensions = build_extensions_for_modules_cython(
-        particles_extensions, particles_modules)
+        particles_extensions, particles_modules
+    )
 else:
-    particles_extensions = build_extensions_for_modules(particles_extensions,
-                                                        particles_modules_c)
+    particles_extensions = build_extensions_for_modules(
+        particles_extensions, particles_modules_c
+    )
 
 setup(
     name='KivEnt particles',
     version='2.0.0',
-    description='''A game engine for the Kivy Framework.
-        https://github.com/Kovak/KivEnt for more info.''',
+    description="""A game engine for the Kivy Framework.
+        https://github.com/Kovak/KivEnt for more info.""",
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
     ext_modules=particles_extensions,
@@ -181,5 +170,5 @@ setup(
         'kivent_particles',
     ],
     package_dir={'kivent_particles': 'kivent_particles'},
-    package_data={'kivent_particles': ['*.pxd', ]}
+    package_data={'kivent_particles': ['*.pxd']},
 )

--- a/modules/projectiles/setup.py
+++ b/modules/projectiles/setup.py
@@ -75,7 +75,7 @@ elif platform == 'darwin':
     if v[2] >= '13.0.0':
         import platform as _platform
 
-        xcode_dev = check_output('xcode-select -p').decode().strip()
+        xcode_dev = check_output(['xcode-select', '-p']).decode().strip()
         sdk_mac_ver = '.'.join(_platform.mac_ver()[0].split('.')[:2])
         sysroot = join(xcode_dev,
                        'Platforms/MacOSX.platform/Developer/SDKs',

--- a/modules/projectiles/setup.py
+++ b/modules/projectiles/setup.py
@@ -61,7 +61,13 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    if sys.maxsize > 2 ** 32:
+    import platform as _pf
+
+    machine = _pf.machine()
+
+    if machine == 'arm64':
+        osx_arch = 'arm64'
+    elif sys.maxsize > 2 ** 32:
         osx_arch = 'x86_64'
     else:
         osx_arch = 'i386'

--- a/modules/projectiles/setup.py
+++ b/modules/projectiles/setup.py
@@ -1,14 +1,14 @@
 from os import environ, remove
-from platform import uname
-from os.path import join, isfile, exists
-from subprocess import check_output
+from os.path import exists, isfile, join
 
 if environ.get('KIVENT_USE_SETUPTOOLS'):
-    from setuptools import setup, Extension
+    from setuptools import Extension, setup
+
     print('Using setuptools')
 else:
     from distutils.core import setup
     from distutils.extension import Extension
+
     print('Using distutils')
 
 try:
@@ -40,9 +40,11 @@ elif environ.get('KIVYIOSROOT'):
     extra_link_args = ['-isysroot', sysroot, '-framework', 'OpenGLES']
 elif exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
-    global_include_dirs = ['/opt/vc/include',
-                           '/opt/vc/include/interface/vcos/pthreads',
-                           '/opt/vc/include/interface/vmcs_host/linux']
+    global_include_dirs = [
+        '/opt/vc/include',
+        '/opt/vc/include/interface/vcos/pthreads',
+        '/opt/vc/include/interface/vmcs_host/linux',
+    ]
     library_dirs = ['/opt/vc/lib']
     libraries = ['bcm_host', 'EGL', 'GLESv2']
 elif exists('/usr/lib/arm-linux-gnueabihf/libMali.so'):
@@ -61,32 +63,8 @@ elif platform.startswith('openbsd'):
     global_include_dirs = ['/usr/X11R6/include']
     extra_link_args = ['-L', '/usr/X11R6/lib']
 elif platform == 'darwin':
-    import platform as _pf
-
-    machine = _pf.machine()
-
-    if machine == 'arm64':
-        osx_arch = 'arm64'
-    elif sys.maxsize > 2 ** 32:
-        osx_arch = 'x86_64'
-    else:
-        osx_arch = 'i386'
-    v = uname()
-    if v[2] >= '13.0.0':
-        import platform as _platform
-
-        xcode_dev = check_output(['xcode-select', '-p']).decode().strip()
-        sdk_mac_ver = '.'.join(_platform.mac_ver()[0].split('.')[:2])
-        sysroot = join(xcode_dev,
-                       'Platforms/MacOSX.platform/Developer/SDKs',
-                       'MacOSX{}.sdk'.format(sdk_mac_ver),
-                       'System/Library/Frameworks')
-    else:
-        sysroot = ('/System/Library/Frameworks/'
-                   'ApplicationServices.framework/Frameworks')
-    extra_compile_args = ['-F' + sysroot, '-arch', osx_arch]
-    extra_link_args = ['-F' + sysroot, '-arch', osx_arch,
-                       '-framework', 'OpenGL']
+    extra_compile_args = []
+    extra_link_args = ['-framework', 'OpenGL', '-framework', 'ApplicationServices']
     libraries = []
 
 do_clear_existing = True
@@ -114,11 +92,16 @@ check_for_removal = [
 ]
 
 
-def build_ext(ext_name, files, include_dirs=cymunk.get_includes()):
-    return Extension(ext_name, files, global_include_dirs + include_dirs,
-                     extra_compile_args=[cstdarg, '-ffast-math', ] + extra_compile_args,
-                     libraries=libraries, extra_link_args=extra_link_args,
-                     library_dirs=library_dirs)
+def build_ext(ext_name, files):
+    return Extension(
+        ext_name,
+        files,
+        global_include_dirs + cymunk.get_includes(),
+        extra_compile_args=[cstdarg, '-ffast-math'] + extra_compile_args,
+        libraries=libraries,
+        extra_link_args=extra_link_args,
+        library_dirs=library_dirs,
+    )
 
 
 extensions = []
@@ -133,7 +116,7 @@ def build_extensions_for_modules_cython(ext_list, modules):
         if environ.get('READTHEDOCS', None) == 'True':
             ext.pyrex_directives = {'embedsignature': True}
         ext_a(ext)
-    return cythonize(ext_list, compiler_directives={'language_level' : "3"})
+    return cythonize(ext_list, compiler_directives={'language_level': '3'})
 
 
 def build_extensions_for_modules(ext_list, modules):
@@ -152,16 +135,18 @@ if have_cython:
             if isfile(file_name):
                 remove(file_name)
     projectiles_extensions = build_extensions_for_modules_cython(
-        projectiles_extensions, projectiles_modules)
+        projectiles_extensions, projectiles_modules
+    )
 else:
     projectiles_extensions = build_extensions_for_modules(
-        projectiles_extensions, projectiles_modules_c)
+        projectiles_extensions, projectiles_modules_c
+    )
 
 setup(
     name='KivEnt projectiles',
     version='2.0.0',
-    description='''A game engine for the Kivy Framework.
-        https://github.com/Kovak/KivEnt for more info.''',
+    description="""A game engine for the Kivy Framework.
+        https://github.com/Kovak/KivEnt for more info.""",
     author='Jacob Kovac',
     author_email='kovac1066@gmail.com',
     ext_modules=projectiles_extensions,
@@ -170,4 +155,9 @@ setup(
         'kivent_projectiles',
     ],
     package_dir={'kivent_projectiles': 'kivent_projectiles'},
-    package_data={'kivent_projectiles': ['*.pxd', ]})
+    package_data={
+        'kivent_projectiles': [
+            '*.pxd',
+        ]
+    },
+)


### PR DESCRIPTION
This pull request updates the macOS architecture detection logic in the `setup.py` files for several modules to properly support Apple Silicon (`arm64`) in addition to existing architectures. The new logic uses the `platform.machine()` method to check for `arm64` before falling back to previous checks.

Architecture detection improvements for macOS builds:

* Updated `setup.py` in `modules/core`, `modules/cymunk`, `modules/particles`, and `modules/projectiles` to detect `arm64` using `platform.machine()` and set `osx_arch` accordingly, ensuring compatibility with Apple Silicon Macs. [[1]](diffhunk://#diff-fb7b51f4f990706f7175b4fc6b8d84506d202b34eb3de9fbba41e60449e8f181L66-R72) [[2]](diffhunk://#diff-db88890d0b8cdaf3475948eff521594ba5dd752ac9b55bd95abad5cf8d4e18c5L65-R71) [[3]](diffhunk://#diff-543799ccf7d1be5488c531dd70c9a0db9882d7e3b1ad85c86b01354d5e5e657cL66-R72) [[4]](diffhunk://#diff-a7bda69a7038d51c48b38be489596f8e59512b5bf407dd8a9d6941607404da30L64-R70)